### PR TITLE
[FEAT] 게시글 CQRS 테이블 생성, 삭제, 수정 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.application;
+
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+
+public interface ReplicaBoardService {
+
+	void createReplicaBoard(BoardCreateEventDto eventDto);
+
+	void deleteReplicaBoard(BoardDeleteEventDto eventDto);
+
+	void updateReplicaBoard(BoardUpdateEventDto eventDto);
+}

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -1,0 +1,70 @@
+package hobbiedo.board.application;
+
+import static hobbiedo.global.api.code.status.ErrorStatus.*;
+
+import org.springframework.stereotype.Service;
+
+import hobbiedo.board.domain.ReplicaBoard;
+import hobbiedo.board.infrastructure.ReplicaBoardRepository;
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReplicaBoardServiceImpl implements ReplicaBoardService {
+
+	private final ReplicaBoardRepository replicaBoardRepository;
+
+	@Override
+	public void createReplicaBoard(BoardCreateEventDto eventDto) {
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.boardId(eventDto.getBoardId())
+				.crewId(eventDto.getCrewId())
+				.content(eventDto.getContent())
+				.writerUuid(eventDto.getWriterUuid())
+				.pinned(eventDto.isPinned())
+				.createdAt(eventDto.getCreatedAt())
+				.updated(eventDto.isUpdated())
+				.imageUrls(eventDto.getImageUrls())
+				.commentCount(0)
+				.likeCount(0)
+				.build()
+		);
+	}
+
+	@Override
+	public void deleteReplicaBoard(BoardDeleteEventDto eventDto) {
+
+		replicaBoardRepository.deleteByBoardId(eventDto.getBoardId());
+	}
+
+	@Override
+	public void updateReplicaBoard(BoardUpdateEventDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(eventDto.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(true)
+				.imageUrls(eventDto.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
@@ -1,0 +1,57 @@
+package hobbiedo.board.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nonapi.io.github.classgraph.json.Id;
+
+@Document(collection = "replica_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReplicaBoard {
+
+	@Id
+	private String id;
+	private Long boardId;
+	private Long crewId;
+	private String content;
+	private String writerUuid;
+	private boolean pinned;
+	private LocalDateTime createdAt;
+	private boolean updated;
+	private List<String> imageUrls;
+	private Integer likeCount;
+	private Integer commentCount;
+	private String profileImageUrl;
+	private String writerName;
+
+	@Builder
+	public ReplicaBoard(String id, Long boardId, Long crewId, String content, String writerUuid,
+		boolean pinned,
+		LocalDateTime createdAt, boolean updated, List<String> imageUrls, Integer likeCount,
+		Integer commentCount,
+		String profileImageUrl, String writerName) {
+		this.id = id;
+		this.boardId = boardId;
+		this.crewId = crewId;
+		this.content = content;
+		this.writerUuid = writerUuid;
+		this.pinned = pinned;
+		this.createdAt = createdAt;
+		this.updated = updated;
+		this.imageUrls = imageUrls;
+		this.likeCount = likeCount;
+		this.commentCount = commentCount;
+		this.profileImageUrl = profileImageUrl;
+		this.writerName = writerName;
+	}
+}

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.board.domain.ReplicaBoard;
+
+public interface ReplicaBoardRepository extends MongoRepository<ReplicaBoard, String> {
+
+	void deleteByBoardId(Long boardId);
+
+	Optional<ReplicaBoard> findByBoardId(Long boardId);
+}

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -1,0 +1,55 @@
+package hobbiedo.board.kafka.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+	private static final Logger log = LoggerFactory.getLogger(KafkaConsumerService.class);
+	private final ReplicaBoardService replicaBoardService;
+
+	/**
+	 * 게시글 생성 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-create-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "createKafkaListenerContainerFactory")
+	public void listenToBoardCreateTopic(BoardCreateEventDto eventDto) {
+
+		log.info("Received board create event: {}", eventDto);
+
+		replicaBoardService.createReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 삭제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "deleteKafkaListenerContainerFactory")
+	public void listenToBoardDeleteTopic(BoardDeleteEventDto eventDto) {
+
+		replicaBoardService.deleteReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 수정 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "updateKafkaListenerContainerFactory")
+	public void listenToBoardUpdateTopic(BoardUpdateEventDto eventDto) {
+
+		replicaBoardService.updateReplicaBoard(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
@@ -1,0 +1,23 @@
+package hobbiedo.board.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCreateEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+	private String content; // 내용
+	private String writerUuid; // 작성자 uuid
+	private boolean pinned; // 고정 여부
+	private LocalDateTime createdAt; // 작성일
+	private boolean updated; // 수정 여부
+	private List<String> imageUrls; // 이미지 url 목록
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteEventDto.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDeleteEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardLikeUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardPinEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardPinEventDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardPinEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardUnPinEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardUnPinEventDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardUnPinEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardUpdateEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardUpdateEventDto.java
@@ -1,0 +1,25 @@
+package hobbiedo.board.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardUpdateEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+	private String content; // 내용
+	private String writerUuid; // 작성자 uuid
+	private boolean pinned; // 고정 여부
+	private LocalDateTime createdAt; // 작성일
+	private boolean updated; // 수정 여부
+	private List<String> imageUrls; // 이미지 url 목록
+}

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -11,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 	VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "GLOBAL400", "데이터베이스 유효성 에러"),
-	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다");
+	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
+
+	// 게시글 조회 에러
+	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -6,10 +6,17 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -23,14 +30,90 @@ public class KafkaBoardConsumerConfig {
 	@Value("${spring.kafka.consumer.group-id}")
 	private String groupId;
 
-	private Map<String, Object> consumerConfigs() {
-		Map<String, Object> props = new HashMap<>();
-		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
-		return props;
+	/**
+	 * 게시글 테이블 생성 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCreateEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCreateEventDto> createConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCreateEventDto.class, false));
 	}
 
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> createKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(createConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 삭제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardDeleteEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardDeleteEventDto> deleteConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardDeleteEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> deleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(deleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 댓글 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardUpdateEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardUpdateEventDto> updateConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardUpdateEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> updateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(updateConsumerFactory());
+
+		return factory;
+	}
 }


### PR DESCRIPTION
## 📣 게시글 CQRS 테이블 생성, 삭제, 수정 기능 추가
### 📅 날짜 - 2024.06.21

### 🌵Branch
feature/add-delete-board-replica-table  → develop

### 📢 Description
**게시판 서비스에서 게시글 생성, 수정, 삭제 토픽을 날리게 되면 컨슈머로 받아서 해당 게시글 CQRS 테아블을 생성한다**

### 💬Issue Number
[#1 ] - 💫[FEAT] 게시글 CQRS 테이블 생성, 삭제, 수정 기능 추가 #1

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
Swagger 와 mongodb compass 를 통해 cqrs 테이블들이 업데이트 되는 것을 확인하였다