### PR TITLE
[FEAT] CQRS 게시글 고정 여부 업데이트 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -2,6 +2,8 @@ package hobbiedo.board.application;
 
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 
 public interface ReplicaBoardService {
@@ -11,4 +13,8 @@ public interface ReplicaBoardService {
 	void deleteReplicaBoard(BoardDeleteEventDto eventDto);
 
 	void updateReplicaBoard(BoardUpdateEventDto eventDto);
+
+	void pinReplicaBoard(BoardPinEventDto eventDto);
+
+	void unPinReplicaBoard(BoardUnPinEventDto eventDto);
 }

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import hobbiedo.board.application.ReplicaBoardService;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
@@ -51,5 +53,27 @@ public class KafkaConsumerService {
 	public void listenToBoardUpdateTopic(BoardUpdateEventDto eventDto) {
 
 		replicaBoardService.updateReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 고정 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-pin-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "pinKafkaListenerContainerFactory")
+	public void listenToBoardPinTopic(BoardPinEventDto eventDto) {
+
+		replicaBoardService.pinReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 고정 해제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-unpin-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "unpinKafkaListenerContainerFactory")
+	public void listenToBoardUnPinTopic(BoardUnPinEventDto eventDto) {
+
+		replicaBoardService.unPinReplicaBoard(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentCountUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentCountUpdateDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardCommentUpdateDto {
+public class BoardCommentCountUpdateDto {
 
 	private Long boardId;
+	private Integer commentCount;
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardLikeCountUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardLikeCountUpdateDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardLikeUpdateDto {
+public class BoardLikeCountUpdateDto {
 
 	private Long boardId;
+	private Integer likeCount;
 }

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -16,6 +16,8 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
@@ -31,18 +33,27 @@ public class KafkaBoardConsumerConfig {
 	private String groupId;
 
 	/**
+	 * Consumer 설정
+	 * @return Map<String, Object>
+	 */
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+	/**
 	 * 게시글 테이블 생성 이벤트용 ConsumerFactory
 	 * @return ConsumerFactory<String, BoardCreateEventDto>
 	 */
 	@Bean
 	public ConsumerFactory<String, BoardCreateEventDto> createConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardCreateEventDto.class, false));
@@ -66,12 +77,7 @@ public class KafkaBoardConsumerConfig {
 	@Bean
 	public ConsumerFactory<String, BoardDeleteEventDto> deleteConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardDeleteEventDto.class, false));
@@ -89,18 +95,13 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	/**
-	 * 게시글 테이블 댓글 증가 이벤트용 ConsumerFactory
+	 * 게시글 테이블 수정 이벤트용 ConsumerFactory
 	 * @return ConsumerFactory<String, BoardUpdateEventDto>
 	 */
 	@Bean
 	public ConsumerFactory<String, BoardUpdateEventDto> updateConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardUpdateEventDto.class, false));
@@ -113,6 +114,54 @@ public class KafkaBoardConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(updateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 고정 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardPinEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardPinEventDto> pinConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardPinEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> pinKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(pinConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 고정 해제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardUnPinEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardUnPinEventDto> unpinConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardUnPinEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> unpinKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(unpinConsumerFactory());
 
 		return factory;
 	}


### PR DESCRIPTION
## 📣 CQRS 게시글 고정 여부 업데이트 기능 추가
### 📅 날짜 -  2024.06.21

### 🌵Branch
feature/update-pinned-status  → develop

### 📢 Description
**게시판 서비스로부터 받은 게시글 고정, 고정 해제 토픽을 감지하면 해당 boardId 의 테이블의 고정여부를 업데이트한다**

### 💬Issue Number
[#3 ] - 💫[FEAT] CQRS 게시글 고정 여부 업데이트 기능 추가 #3

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 와 Mongo DB Compass 를 통해 잘 작동하는 것을 확인하였고, 특히 한 소모임 내 기존에 고정된 게시글이 있고 새로운 게시글을 고정할 시, 기존 고정 게시글의 고정여부가 false 까지 잘 되는 것을 확인하였다