### PR TITLE
[FEAT] CQRS 게시글 테이블 좋아요 수, 댓글 수 업데이트 로직 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -1,7 +1,9 @@
 package hobbiedo.board.application;
 
+import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
@@ -17,4 +19,12 @@ public interface ReplicaBoardService {
 	void pinReplicaBoard(BoardPinEventDto eventDto);
 
 	void unPinReplicaBoard(BoardUnPinEventDto eventDto);
+
+	void increaseCommentCount(BoardCommentCountUpdateDto eventDto);
+
+	void decreaseCommentCount(BoardCommentCountUpdateDto eventDto);
+
+	void increaseLikeCount(BoardLikeCountUpdateDto eventDto);
+
+	void decreaseLikeCount(BoardLikeCountUpdateDto eventDto);
 }

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 
 import hobbiedo.board.domain.ReplicaBoard;
 import hobbiedo.board.infrastructure.ReplicaBoardRepository;
+import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
@@ -132,6 +134,114 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 				.imageUrls(replicaBoard.getImageUrls())
 				.commentCount(replicaBoard.getCommentCount())
 				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 댓글 수 증가
+	 * @param eventDto
+	 */
+	@Override
+	public void increaseCommentCount(BoardCommentCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount() + 1)
+				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 댓글 수 감소
+	 * @param eventDto
+	 */
+	@Override
+	public void decreaseCommentCount(BoardCommentCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount() - 1)
+				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 좋아요 수 증가
+	 * @param eventDto
+	 */
+	@Override
+	public void increaseLikeCount(BoardLikeCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount() + 1)
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 좋아요 수 감소
+	 * @param eventDto
+	 */
+	@Override
+	public void decreaseLikeCount(BoardLikeCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount() - 1)
 				.build()
 		);
 	}

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -6,8 +6,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
@@ -75,5 +77,49 @@ public class KafkaConsumerService {
 	public void listenToBoardUnPinTopic(BoardUnPinEventDto eventDto) {
 
 		replicaBoardService.unPinReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 수 증가 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-comment-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentCountUpdateKafkaListenerContainerFactory")
+	public void listenToCommentCountUpdateTopic(BoardCommentCountUpdateDto eventDto) {
+
+		replicaBoardService.increaseCommentCount(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 수 감소 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-comment-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentCountDeleteKafkaListenerContainerFactory")
+	public void listenToCommentCountDeleteTopic(BoardCommentCountUpdateDto eventDto) {
+
+		replicaBoardService.decreaseCommentCount(eventDto);
+	}
+
+	/**
+	 * 게시글 좋아요 수 증가 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-like-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "likeCountUpdateKafkaListenerContainerFactory")
+	public void listenToLikeCountUpdateTopic(BoardLikeCountUpdateDto eventDto) {
+
+		replicaBoardService.increaseLikeCount(eventDto);
+	}
+
+	/**
+	 * 게시글 좋아요 수 감소 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-like-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "likeCountDeleteKafkaListenerContainerFactory")
+	public void listenToLikeCountDeleteTopic(BoardLikeCountUpdateDto eventDto) {
+
+		replicaBoardService.decreaseLikeCount(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -14,8 +14,10 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
@@ -162,6 +164,102 @@ public class KafkaBoardConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(unpinConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 댓글 수 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentCountUpdateDto> commentCountUpdateConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> commentCountUpdateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentCountUpdateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 댓글 수 감소 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentCountUpdateDto> commentCountDeleteConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> commentCountDeleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentCountDeleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 좋아요 수 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardLikeCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardLikeCountUpdateDto> likeCountUpdateConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardLikeCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> likeCountUpdateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(likeCountUpdateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 좋아요 수 감소 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardLikeCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardLikeCountUpdateDto> likeCountDeleteConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardLikeCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> likeCountDeleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(likeCountDeleteConsumerFactory());
 
 		return factory;
 	}


### PR DESCRIPTION
## 📣 CQRS 게시글 테이블 좋아요 수, 댓글 수 업데이트 로직 추가
### 📅 날짜 -  2024.06.21

### 🌵Branch
feature/update-like-comment-count  → develop

### 📢 Description
**게시글 통계 테이블을 관리하는 배치 서비스에서 날아온 댓글 수, 좋아요 수 업데이트 토픽을 감지하면 해당 토픽이 어떤 토픽인지 구분하고 CQRS 게시글 테이블에서 댓글 수와 좋아요 수를 증가 또는 감소 시키는 로직을 추가하였다**

### 💬Issue Number
[#5 ] - 💫[FEAT] CQRS 게시글 테이블 좋아요 수, 댓글 수 업데이트 로직 추가 #5

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1.  Swagger 와 Mongo DB Compass 를 통해 댓글 수와 좋아요 수를 업데이트하면 몽고 디비의 CQRS 테이블이 수정되는 것을 확인하였다
2. 현재는 해당 토픽에 따라 댓글 수와 좋아요 수를 +1 또는 -1 하지만 추후 배치 시스템을 적용하면 토픽 메세지 내 데이터의 변활될 댓글 수 또는 좋아요 수를 추출하여 테이블에 추가하도록 할 예정이다