### PR TITLE
[FEAT] CQRS 회원 프로필 저장 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,39 @@
-HELP.md
-.gradle
-build/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
-
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
-
-### IntelliJ IDEA ###
+# Default ignored files
+/shelf/
+/.idea/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+### Java template
+*.class
+#PackageFiles
+*.jar
+*.war
+*.ear
+###macOStemplate
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store
+.AppleDouble
+.LSOverride
+#IntelliJprojectfiles
 .idea
-*.iws
+.idea/*.xml
 *.iml
-*.ipr
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
-
-### VS Code ###
-.vscode/
-
-### application yaml ###
-application.yml
-application-local.yml
-application-prod.yml
+out
+gen
+build
+rebel.xml
+#Compliledfiles
+/target/
+**/target
+/example/
+#Gradle
+.gradle
+/build/
+.gradletasknamecache
+#gitignore
+.gitignore

--- a/src/main/java/hobbiedo/ReadonlyApplication.java
+++ b/src/main/java/hobbiedo/ReadonlyApplication.java
@@ -1,4 +1,4 @@
-package hobbiedo.readonly;
+package hobbiedo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.application;
+
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+
+public interface ReplicaBoardService {
+
+	void createReplicaBoard(BoardCreateEventDto eventDto);
+
+	void deleteReplicaBoard(BoardDeleteEventDto eventDto);
+
+	void updateReplicaBoard(BoardUpdateEventDto eventDto);
+}

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -2,6 +2,8 @@ package hobbiedo.board.application;
 
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 
 public interface ReplicaBoardService {
@@ -11,4 +13,8 @@ public interface ReplicaBoardService {
 	void deleteReplicaBoard(BoardDeleteEventDto eventDto);
 
 	void updateReplicaBoard(BoardUpdateEventDto eventDto);
+
+	void pinReplicaBoard(BoardPinEventDto eventDto);
+
+	void unPinReplicaBoard(BoardUnPinEventDto eventDto);
 }

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -1,0 +1,70 @@
+package hobbiedo.board.application;
+
+import static hobbiedo.global.api.code.status.ErrorStatus.*;
+
+import org.springframework.stereotype.Service;
+
+import hobbiedo.board.domain.ReplicaBoard;
+import hobbiedo.board.infrastructure.ReplicaBoardRepository;
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReplicaBoardServiceImpl implements ReplicaBoardService {
+
+	private final ReplicaBoardRepository replicaBoardRepository;
+
+	@Override
+	public void createReplicaBoard(BoardCreateEventDto eventDto) {
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.boardId(eventDto.getBoardId())
+				.crewId(eventDto.getCrewId())
+				.content(eventDto.getContent())
+				.writerUuid(eventDto.getWriterUuid())
+				.pinned(eventDto.isPinned())
+				.createdAt(eventDto.getCreatedAt())
+				.updated(eventDto.isUpdated())
+				.imageUrls(eventDto.getImageUrls())
+				.commentCount(0)
+				.likeCount(0)
+				.build()
+		);
+	}
+
+	@Override
+	public void deleteReplicaBoard(BoardDeleteEventDto eventDto) {
+
+		replicaBoardRepository.deleteByBoardId(eventDto.getBoardId());
+	}
+
+	@Override
+	public void updateReplicaBoard(BoardUpdateEventDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(eventDto.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(true)
+				.imageUrls(eventDto.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
@@ -1,0 +1,57 @@
+package hobbiedo.board.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nonapi.io.github.classgraph.json.Id;
+
+@Document(collection = "replica_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReplicaBoard {
+
+	@Id
+	private String id;
+	private Long boardId;
+	private Long crewId;
+	private String content;
+	private String writerUuid;
+	private boolean pinned;
+	private LocalDateTime createdAt;
+	private boolean updated;
+	private List<String> imageUrls;
+	private Integer likeCount;
+	private Integer commentCount;
+	private String profileImageUrl;
+	private String writerName;
+
+	@Builder
+	public ReplicaBoard(String id, Long boardId, Long crewId, String content, String writerUuid,
+		boolean pinned,
+		LocalDateTime createdAt, boolean updated, List<String> imageUrls, Integer likeCount,
+		Integer commentCount,
+		String profileImageUrl, String writerName) {
+		this.id = id;
+		this.boardId = boardId;
+		this.crewId = crewId;
+		this.content = content;
+		this.writerUuid = writerUuid;
+		this.pinned = pinned;
+		this.createdAt = createdAt;
+		this.updated = updated;
+		this.imageUrls = imageUrls;
+		this.likeCount = likeCount;
+		this.commentCount = commentCount;
+		this.profileImageUrl = profileImageUrl;
+		this.writerName = writerName;
+	}
+}

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.board.domain.ReplicaBoard;
+
+public interface ReplicaBoardRepository extends MongoRepository<ReplicaBoard, String> {
+
+	void deleteByBoardId(Long boardId);
+
+	Optional<ReplicaBoard> findByBoardId(Long boardId);
+}

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import hobbiedo.board.application.ReplicaBoardService;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
@@ -51,5 +53,27 @@ public class KafkaConsumerService {
 	public void listenToBoardUpdateTopic(BoardUpdateEventDto eventDto) {
 
 		replicaBoardService.updateReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 고정 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-pin-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "pinKafkaListenerContainerFactory")
+	public void listenToBoardPinTopic(BoardPinEventDto eventDto) {
+
+		replicaBoardService.pinReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 고정 해제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-unpin-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "unpinKafkaListenerContainerFactory")
+	public void listenToBoardUnPinTopic(BoardUnPinEventDto eventDto) {
+
+		replicaBoardService.unPinReplicaBoard(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -1,0 +1,55 @@
+package hobbiedo.board.kafka.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+	private static final Logger log = LoggerFactory.getLogger(KafkaConsumerService.class);
+	private final ReplicaBoardService replicaBoardService;
+
+	/**
+	 * 게시글 생성 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-create-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "createKafkaListenerContainerFactory")
+	public void listenToBoardCreateTopic(BoardCreateEventDto eventDto) {
+
+		log.info("Received board create event: {}", eventDto);
+
+		replicaBoardService.createReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 삭제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "deleteKafkaListenerContainerFactory")
+	public void listenToBoardDeleteTopic(BoardDeleteEventDto eventDto) {
+
+		replicaBoardService.deleteReplicaBoard(eventDto);
+	}
+
+	/**
+	 * 게시글 수정 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "updateKafkaListenerContainerFactory")
+	public void listenToBoardUpdateTopic(BoardUpdateEventDto eventDto) {
+
+		replicaBoardService.updateReplicaBoard(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentCountUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentCountUpdateDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardCommentUpdateDto {
+public class BoardCommentCountUpdateDto {
 
 	private Long boardId;
+	private Integer commentCount;
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCreateEventDto.java
@@ -1,0 +1,23 @@
+package hobbiedo.board.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCreateEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+	private String content; // 내용
+	private String writerUuid; // 작성자 uuid
+	private boolean pinned; // 고정 여부
+	private LocalDateTime createdAt; // 작성일
+	private boolean updated; // 수정 여부
+	private List<String> imageUrls; // 이미지 url 목록
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardDeleteEventDto.java
@@ -1,0 +1,14 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDeleteEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardLikeCountUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardLikeCountUpdateDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class BoardLikeUpdateDto {
+public class BoardLikeCountUpdateDto {
 
 	private Long boardId;
+	private Integer likeCount;
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardLikeUpdateDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardLikeUpdateDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardPinEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardPinEventDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardPinEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardUnPinEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardUnPinEventDto.java
@@ -1,0 +1,15 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardUnPinEventDto {
+
+	private Long boardId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardUpdateEventDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardUpdateEventDto.java
@@ -1,0 +1,25 @@
+package hobbiedo.board.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardUpdateEventDto {
+
+	private Long boardId; // 게시글 번호
+	private Long crewId; // 크루 번호
+	private String content; // 내용
+	private String writerUuid; // 작성자 uuid
+	private boolean pinned; // 고정 여부
+	private LocalDateTime createdAt; // 작성일
+	private boolean updated; // 수정 여부
+	private List<String> imageUrls; // 이미지 url 목록
+}

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -14,7 +14,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
 
 	// 게시글 조회 에러
-	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다.");
+	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다."),
+
+	// MemberProfile
+	NOT_FOUND_MEMBER_PROFILE(HttpStatus.NOT_FOUND, "MEMBER401", "회원 프로필을 찾을 수 없습니다."),;
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -11,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 	VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "GLOBAL400", "데이터베이스 유효성 에러"),
-	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다");
+	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
+
+	// 게시글 조회 에러
+	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
+++ b/src/main/java/hobbiedo/global/config/KafkaProducerConfig.java
@@ -1,0 +1,43 @@
+package hobbiedo.global.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+	// 카프카 주소
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers; // static 제거
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+			JsonSerializer.class); // JsonSerializer 사용함으로써 객체 JSON 으로 변환
+
+		return new DefaultKafkaProducerFactory<>(configProps);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -16,6 +16,8 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardPinEventDto;
+import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
@@ -31,18 +33,27 @@ public class KafkaBoardConsumerConfig {
 	private String groupId;
 
 	/**
+	 * Consumer 설정
+	 * @return Map<String, Object>
+	 */
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+	/**
 	 * 게시글 테이블 생성 이벤트용 ConsumerFactory
 	 * @return ConsumerFactory<String, BoardCreateEventDto>
 	 */
 	@Bean
 	public ConsumerFactory<String, BoardCreateEventDto> createConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardCreateEventDto.class, false));
@@ -66,12 +77,7 @@ public class KafkaBoardConsumerConfig {
 	@Bean
 	public ConsumerFactory<String, BoardDeleteEventDto> deleteConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardDeleteEventDto.class, false));
@@ -89,18 +95,13 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	/**
-	 * 게시글 테이블 댓글 증가 이벤트용 ConsumerFactory
+	 * 게시글 테이블 수정 이벤트용 ConsumerFactory
 	 * @return ConsumerFactory<String, BoardUpdateEventDto>
 	 */
 	@Bean
 	public ConsumerFactory<String, BoardUpdateEventDto> updateConsumerFactory() {
 
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		Map<String, Object> configProps = consumerConfigs();
 
 		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
 			new JsonDeserializer<>(BoardUpdateEventDto.class, false));
@@ -113,6 +114,54 @@ public class KafkaBoardConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(updateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 고정 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardPinEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardPinEventDto> pinConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardPinEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> pinKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(pinConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 고정 해제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardUnPinEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardUnPinEventDto> unpinConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardUnPinEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> unpinKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(unpinConsumerFactory());
 
 		return factory;
 	}

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -6,10 +6,17 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hobbiedo.board.kafka.dto.BoardCreateEventDto;
+import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
+import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -23,14 +30,90 @@ public class KafkaBoardConsumerConfig {
 	@Value("${spring.kafka.consumer.group-id}")
 	private String groupId;
 
-	private Map<String, Object> consumerConfigs() {
-		Map<String, Object> props = new HashMap<>();
-		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
-		return props;
+	/**
+	 * 게시글 테이블 생성 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCreateEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCreateEventDto> createConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCreateEventDto.class, false));
 	}
 
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> createKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(createConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 삭제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardDeleteEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardDeleteEventDto> deleteConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardDeleteEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> deleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(deleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 테이블 댓글 증가 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardUpdateEventDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardUpdateEventDto> updateConsumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardUpdateEventDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> updateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(updateConsumerFactory());
+
+		return factory;
+	}
 }

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -1,0 +1,36 @@
+package hobbiedo.global.config.consumer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaBoardConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+}

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaChatConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaChatConsumerConfig.java
@@ -1,0 +1,36 @@
+package hobbiedo.global.config.consumer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaChatConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+}

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaMemberConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaMemberConsumerConfig.java
@@ -1,0 +1,94 @@
+package hobbiedo.global.config.consumer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaMemberConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	/**
+	 * Consumer 설정
+	 * @return Map<String, Object>
+	 */
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+	/**
+	 * 회원 가입 이벤트 ConsumerFactory - memberProfile 생성
+	 * @return ConsumerFactory<String, SignUpDTO>
+	 */
+	@Bean
+	public ConsumerFactory<String, SignUpDTO> signUpConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(SignUpDTO.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, SignUpDTO> signUpKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, SignUpDTO> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(signUpConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 프로필 수정 ConsumerFactory - memberProfile 수정
+	 * @return ConsumerFactory<String, ModifyProfileDTO>
+	 */
+	@Bean
+	public ConsumerFactory<String, ModifyProfileDTO> modifyProfileConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(ModifyProfileDTO.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, ModifyProfileDTO>
+		modifyProfileKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, ModifyProfileDTO> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(modifyProfileConsumerFactory());
+
+		return factory;
+	}
+}

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
@@ -1,0 +1,10 @@
+package hobbiedo.member.application;
+
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+
+public interface ReplicaMemberService {
+	void createMemberProfile(SignUpDTO signUpDTO);
+
+	void updateMemberProfile(ModifyProfileDTO modifyProfileDTO);
+}

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
@@ -1,7 +1,6 @@
 package hobbiedo.member.application;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import hobbiedo.global.api.code.status.ErrorStatus;
 import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
@@ -10,23 +9,17 @@ import hobbiedo.member.infrastructure.ReplicaMemberRepository;
 import hobbiedo.member.kafka.dto.ModifyProfileDTO;
 import hobbiedo.member.kafka.dto.SignUpDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-@Slf4j
 public class ReplicaMemberServiceImp implements ReplicaMemberService {
 	private final ReplicaMemberRepository replicaMemberRepository;
 
-	@Transactional
 	@Override
 	public void createMemberProfile(SignUpDTO signUpDTO) {
-		log.info("Sercvice : " + signUpDTO.toString());
 		replicaMemberRepository.save(signUpDTO.toEntity());
 	}
 
-	@Transactional
 	@Override
 	public void updateMemberProfile(ModifyProfileDTO modifyProfileDTO) {
 		MemberProfile memberProfile = replicaMemberRepository.findByUuid(modifyProfileDTO.getUuid())

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
@@ -1,0 +1,36 @@
+package hobbiedo.member.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hobbiedo.global.api.code.status.ErrorStatus;
+import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import hobbiedo.member.domain.MemberProfile;
+import hobbiedo.member.infrastructure.ReplicaMemberRepository;
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ReplicaMemberServiceImp implements ReplicaMemberService {
+	private final ReplicaMemberRepository replicaMemberRepository;
+
+	@Transactional
+	@Override
+	public void createMemberProfile(SignUpDTO signUpDTO) {
+		log.info("Sercvice : " + signUpDTO.toString());
+		replicaMemberRepository.save(signUpDTO.toEntity());
+	}
+
+	@Transactional
+	@Override
+	public void updateMemberProfile(ModifyProfileDTO modifyProfileDTO) {
+		MemberProfile memberProfile = replicaMemberRepository.findByUuid(modifyProfileDTO.getUuid())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE));
+		replicaMemberRepository.save(modifyProfileDTO.toEntity(memberProfile));
+	}
+}

--- a/src/main/java/hobbiedo/member/domain/MemberProfile.java
+++ b/src/main/java/hobbiedo/member/domain/MemberProfile.java
@@ -1,0 +1,31 @@
+package hobbiedo.member.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "replica_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MemberProfile {
+	@Id
+	private String id;
+	private String uuid;
+	private String name;
+	private String profileUrl;
+
+	@Builder
+	public MemberProfile(String id, String uuid, String name, String profileUrl) {
+		this.id = id;
+		this.uuid = uuid;
+		this.name = name;
+		this.profileUrl = profileUrl;
+	}
+}

--- a/src/main/java/hobbiedo/member/infrastructure/ReplicaMemberRepository.java
+++ b/src/main/java/hobbiedo/member/infrastructure/ReplicaMemberRepository.java
@@ -1,0 +1,11 @@
+package hobbiedo.member.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.member.domain.MemberProfile;
+
+public interface ReplicaMemberRepository extends MongoRepository<MemberProfile, String> {
+	Optional<MemberProfile> findByUuid(String uuid);
+}

--- a/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
+++ b/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
@@ -1,0 +1,31 @@
+package hobbiedo.member.kafka.application;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.member.application.ReplicaMemberService;
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMemberConsumerService {
+
+	private final ReplicaMemberService replicaMemberService;
+
+	@KafkaListener(topics = "sign-up-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "signUpKafkaListenerContainerFactory")
+	public void listenToScoreAddTopic(SignUpDTO eventDto) {
+		log.info("Received: " + eventDto.toString());
+		replicaMemberService.createMemberProfile(eventDto);
+	}
+
+	@KafkaListener(topics = "update-profile-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "modifyProfileKafkaListenerContainerFactory")
+	public void updateMemberProfile(ModifyProfileDTO eventDto) {
+		replicaMemberService.updateMemberProfile(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
+++ b/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
@@ -7,11 +7,9 @@ import hobbiedo.member.application.ReplicaMemberService;
 import hobbiedo.member.kafka.dto.ModifyProfileDTO;
 import hobbiedo.member.kafka.dto.SignUpDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class KafkaMemberConsumerService {
 
 	private final ReplicaMemberService replicaMemberService;
@@ -19,7 +17,6 @@ public class KafkaMemberConsumerService {
 	@KafkaListener(topics = "sign-up-topic", groupId = "${spring.kafka.consumer.group-id}",
 		containerFactory = "signUpKafkaListenerContainerFactory")
 	public void listenToScoreAddTopic(SignUpDTO eventDto) {
-		log.info("Received: " + eventDto.toString());
 		replicaMemberService.createMemberProfile(eventDto);
 	}
 

--- a/src/main/java/hobbiedo/member/kafka/dto/ModifyProfileDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/ModifyProfileDTO.java
@@ -1,0 +1,25 @@
+package hobbiedo.member.kafka.dto;
+
+import hobbiedo.member.domain.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ModifyProfileDTO {
+	private String uuid;
+	private String profileUrl;
+
+	public MemberProfile toEntity(MemberProfile memberProfile) {
+		return MemberProfile.builder()
+			.id(memberProfile.getId())
+			.uuid(memberProfile.getUuid())
+			.name(memberProfile.getName())
+			.profileUrl(profileUrl)
+			.build();
+	}
+}

--- a/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString
 public class SignUpDTO {
 	private String uuid;
 	private String name;

--- a/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
@@ -1,0 +1,27 @@
+package hobbiedo.member.kafka.dto;
+
+import hobbiedo.member.domain.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class SignUpDTO {
+	private String uuid;
+	private String name;
+
+	public MemberProfile toEntity() {
+		return MemberProfile.builder()
+			.uuid(uuid)
+			.name(name)
+			.profileUrl(
+				"https://hobbiedo-bucket.s3.ap-northeast-2.amazonaws.com/image_1718266148717_Frame%201000004039.png")
+			.build();
+	}
+}

--- a/src/test/java/hobbiedo/readonly/ReadonlyApplicationTests.java
+++ b/src/test/java/hobbiedo/readonly/ReadonlyApplicationTests.java
@@ -1,9 +1,7 @@
 package hobbiedo.readonly;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class ReadonlyApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 📣 [FEAT] CQRS 회원 프로필 저장 로직 구현
### 📅 2024.06.22

### 🌵Branch
feature/get-profile-replica → develop

### 📢 Description
CQRS를 위한 read-only 회원 프로필 데이터를 저장하고 업데이트하는 로직을 구현한다.

### 💬Issue Number
[#7 ] - [FEAT] CQRS 회원 프로필 저장 로직 구현

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
