### PR TITLE
[FEAT] CQRS 회원 프로필 저장 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,39 @@
-HELP.md
-.gradle
-build/
-!gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
-
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
-
-### IntelliJ IDEA ###
+# Default ignored files
+/shelf/
+/.idea/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+### Java template
+*.class
+#PackageFiles
+*.jar
+*.war
+*.ear
+###macOStemplate
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store
+.AppleDouble
+.LSOverride
+#IntelliJprojectfiles
 .idea
-*.iws
+.idea/*.xml
 *.iml
-*.ipr
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-### NetBeans ###
-/nbproject/private/
-/nbbuild/
-/dist/
-/nbdist/
-/.nb-gradle/
-
-### VS Code ###
-.vscode/
-
-### application yaml ###
-application.yml
-application-local.yml
-application-prod.yml
+out
+gen
+build
+rebel.xml
+#Compliledfiles
+/target/
+**/target
+/example/
+#Gradle
+.gradle
+/build/
+.gradletasknamecache
+#gitignore
+.gitignore

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -14,7 +14,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
 
 	// 게시글 조회 에러
-	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다.");
+	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다."),
+
+	// MemberProfile
+	NOT_FOUND_MEMBER_PROFILE(HttpStatus.NOT_FOUND, "MEMBER401", "회원 프로필을 찾을 수 없습니다."),;
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaMemberConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaMemberConsumerConfig.java
@@ -1,0 +1,94 @@
+package hobbiedo.global.config.consumer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaMemberConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	/**
+	 * Consumer 설정
+	 * @return Map<String, Object>
+	 */
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+	/**
+	 * 회원 가입 이벤트 ConsumerFactory - memberProfile 생성
+	 * @return ConsumerFactory<String, SignUpDTO>
+	 */
+	@Bean
+	public ConsumerFactory<String, SignUpDTO> signUpConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(SignUpDTO.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, SignUpDTO> signUpKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, SignUpDTO> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(signUpConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 프로필 수정 ConsumerFactory - memberProfile 수정
+	 * @return ConsumerFactory<String, ModifyProfileDTO>
+	 */
+	@Bean
+	public ConsumerFactory<String, ModifyProfileDTO> modifyProfileConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(ModifyProfileDTO.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, ModifyProfileDTO>
+		modifyProfileKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, ModifyProfileDTO> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(modifyProfileConsumerFactory());
+
+		return factory;
+	}
+}

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
@@ -1,0 +1,10 @@
+package hobbiedo.member.application;
+
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+
+public interface ReplicaMemberService {
+	void createMemberProfile(SignUpDTO signUpDTO);
+
+	void updateMemberProfile(ModifyProfileDTO modifyProfileDTO);
+}

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
@@ -1,7 +1,6 @@
 package hobbiedo.member.application;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import hobbiedo.global.api.code.status.ErrorStatus;
 import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
@@ -10,23 +9,17 @@ import hobbiedo.member.infrastructure.ReplicaMemberRepository;
 import hobbiedo.member.kafka.dto.ModifyProfileDTO;
 import hobbiedo.member.kafka.dto.SignUpDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-@Slf4j
 public class ReplicaMemberServiceImp implements ReplicaMemberService {
 	private final ReplicaMemberRepository replicaMemberRepository;
 
-	@Transactional
 	@Override
 	public void createMemberProfile(SignUpDTO signUpDTO) {
-		log.info("Sercvice : " + signUpDTO.toString());
 		replicaMemberRepository.save(signUpDTO.toEntity());
 	}
 
-	@Transactional
 	@Override
 	public void updateMemberProfile(ModifyProfileDTO modifyProfileDTO) {
 		MemberProfile memberProfile = replicaMemberRepository.findByUuid(modifyProfileDTO.getUuid())

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
@@ -1,0 +1,36 @@
+package hobbiedo.member.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hobbiedo.global.api.code.status.ErrorStatus;
+import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import hobbiedo.member.domain.MemberProfile;
+import hobbiedo.member.infrastructure.ReplicaMemberRepository;
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ReplicaMemberServiceImp implements ReplicaMemberService {
+	private final ReplicaMemberRepository replicaMemberRepository;
+
+	@Transactional
+	@Override
+	public void createMemberProfile(SignUpDTO signUpDTO) {
+		log.info("Sercvice : " + signUpDTO.toString());
+		replicaMemberRepository.save(signUpDTO.toEntity());
+	}
+
+	@Transactional
+	@Override
+	public void updateMemberProfile(ModifyProfileDTO modifyProfileDTO) {
+		MemberProfile memberProfile = replicaMemberRepository.findByUuid(modifyProfileDTO.getUuid())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE));
+		replicaMemberRepository.save(modifyProfileDTO.toEntity(memberProfile));
+	}
+}

--- a/src/main/java/hobbiedo/member/domain/MemberProfile.java
+++ b/src/main/java/hobbiedo/member/domain/MemberProfile.java
@@ -1,0 +1,31 @@
+package hobbiedo.member.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "replica_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MemberProfile {
+	@Id
+	private String id;
+	private String uuid;
+	private String name;
+	private String profileUrl;
+
+	@Builder
+	public MemberProfile(String id, String uuid, String name, String profileUrl) {
+		this.id = id;
+		this.uuid = uuid;
+		this.name = name;
+		this.profileUrl = profileUrl;
+	}
+}

--- a/src/main/java/hobbiedo/member/infrastructure/ReplicaMemberRepository.java
+++ b/src/main/java/hobbiedo/member/infrastructure/ReplicaMemberRepository.java
@@ -1,0 +1,11 @@
+package hobbiedo.member.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.member.domain.MemberProfile;
+
+public interface ReplicaMemberRepository extends MongoRepository<MemberProfile, String> {
+	Optional<MemberProfile> findByUuid(String uuid);
+}

--- a/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
+++ b/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
@@ -1,0 +1,31 @@
+package hobbiedo.member.kafka.application;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.member.application.ReplicaMemberService;
+import hobbiedo.member.kafka.dto.ModifyProfileDTO;
+import hobbiedo.member.kafka.dto.SignUpDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMemberConsumerService {
+
+	private final ReplicaMemberService replicaMemberService;
+
+	@KafkaListener(topics = "sign-up-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "signUpKafkaListenerContainerFactory")
+	public void listenToScoreAddTopic(SignUpDTO eventDto) {
+		log.info("Received: " + eventDto.toString());
+		replicaMemberService.createMemberProfile(eventDto);
+	}
+
+	@KafkaListener(topics = "update-profile-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "modifyProfileKafkaListenerContainerFactory")
+	public void updateMemberProfile(ModifyProfileDTO eventDto) {
+		replicaMemberService.updateMemberProfile(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
+++ b/src/main/java/hobbiedo/member/kafka/application/KafkaMemberConsumerService.java
@@ -7,11 +7,9 @@ import hobbiedo.member.application.ReplicaMemberService;
 import hobbiedo.member.kafka.dto.ModifyProfileDTO;
 import hobbiedo.member.kafka.dto.SignUpDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class KafkaMemberConsumerService {
 
 	private final ReplicaMemberService replicaMemberService;
@@ -19,7 +17,6 @@ public class KafkaMemberConsumerService {
 	@KafkaListener(topics = "sign-up-topic", groupId = "${spring.kafka.consumer.group-id}",
 		containerFactory = "signUpKafkaListenerContainerFactory")
 	public void listenToScoreAddTopic(SignUpDTO eventDto) {
-		log.info("Received: " + eventDto.toString());
 		replicaMemberService.createMemberProfile(eventDto);
 	}
 

--- a/src/main/java/hobbiedo/member/kafka/dto/ModifyProfileDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/ModifyProfileDTO.java
@@ -1,0 +1,25 @@
+package hobbiedo.member.kafka.dto;
+
+import hobbiedo.member.domain.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ModifyProfileDTO {
+	private String uuid;
+	private String profileUrl;
+
+	public MemberProfile toEntity(MemberProfile memberProfile) {
+		return MemberProfile.builder()
+			.id(memberProfile.getId())
+			.uuid(memberProfile.getUuid())
+			.name(memberProfile.getName())
+			.profileUrl(profileUrl)
+			.build();
+	}
+}

--- a/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString
 public class SignUpDTO {
 	private String uuid;
 	private String name;

--- a/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
+++ b/src/main/java/hobbiedo/member/kafka/dto/SignUpDTO.java
@@ -1,0 +1,27 @@
+package hobbiedo.member.kafka.dto;
+
+import hobbiedo.member.domain.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class SignUpDTO {
+	private String uuid;
+	private String name;
+
+	public MemberProfile toEntity() {
+		return MemberProfile.builder()
+			.uuid(uuid)
+			.name(name)
+			.profileUrl(
+				"https://hobbiedo-bucket.s3.ap-northeast-2.amazonaws.com/image_1718266148717_Frame%201000004039.png")
+			.build();
+	}
+}


### PR DESCRIPTION
## 📣 [FEAT] CQRS 회원 프로필 저장 로직 구현
### 📅 2024.06.22

### 🌵Branch
feature/get-profile-replica → develop

### 📢 Description
CQRS를 위한 read-only 회원 프로필 데이터를 저장하고 업데이트하는 로직을 구현한다.

### 💬Issue Number
[#7 ] - [FEAT] CQRS 회원 프로필 저장 로직 구현

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
