### PR TITLE
[FEAT] 읽기 전용 게시글 조회 기능 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,49 @@
-# Default ignored files
-/shelf/
-/.idea/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-### Java template
-*.class
-#PackageFiles
-*.jar
-*.war
-*.ear
-###macOStemplate
+HEHELP.md
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### property files ###
+**/application.yml
+**/application-local.yml
+**/application-prod.yml
+
+### .DS_store ###
 .DS_Store
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
-.AppleDouble
-.LSOverride
-#IntelliJprojectfiles
-.idea
-.idea/*.xml
-*.iml
-out
-gen
-build
-rebel.xml
-#Compliledfiles
-/target/
-**/target
-/example/
-#Gradle
-.gradle
-/build/
-.gradletasknamecache
-#gitignore
-.gitignore

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -32,4 +32,6 @@ public interface ReplicaBoardService {
 	BoardDetailsResponseDto getBoard(Long boardId);
 
 	BoardDetailsResponseDto getLatestBoard(Long crewId);
+
+	BoardDetailsResponseDto getPinnedBoard(Long crewId);
 }

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -1,5 +1,6 @@
 package hobbiedo.board.application;
 
+import hobbiedo.board.dto.BoardDetailsResponseDto;
 import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
@@ -27,4 +28,8 @@ public interface ReplicaBoardService {
 	void increaseLikeCount(BoardLikeCountUpdateDto eventDto);
 
 	void decreaseLikeCount(BoardLikeCountUpdateDto eventDto);
+
+	BoardDetailsResponseDto getBoard(Long boardId);
+
+	BoardDetailsResponseDto getLatestBoard(Long crewId);
 }

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -2,6 +2,8 @@ package hobbiedo.board.application;
 
 import static hobbiedo.global.api.code.status.ErrorStatus.*;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import hobbiedo.board.domain.ReplicaBoard;
@@ -307,6 +309,41 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 			.imageUrls(replicaBoard.getImageUrls())
 			.commentCount(replicaBoard.getCommentCount())
 			.likeCount(replicaBoard.getLikeCount())
+			.writerName(writerName)
+			.writerProfileImageUrl(writerProfileImageUrl)
+			.build();
+	}
+
+	/**
+	 * 고정된 게시글 조회
+	 * @param crewId
+	 * @return
+	 */
+	@Override
+	public BoardDetailsResponseDto getPinnedBoard(Long crewId) {
+
+		Optional<ReplicaBoard> replicaBoard = replicaBoardRepository.findByPinnedTrueAndCrewId(
+			crewId);
+
+		if (!replicaBoard.isPresent()) {
+			return null;
+		}
+
+		String writerName = replicaMemberService.getMemberName(replicaBoard.get().getWriterUuid());
+		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
+			replicaBoard.get().getWriterUuid());
+
+		return BoardDetailsResponseDto.builder()
+			.boardId(replicaBoard.get().getBoardId())
+			.crewId(replicaBoard.get().getCrewId())
+			.content(replicaBoard.get().getContent())
+			.writerUuid(replicaBoard.get().getWriterUuid())
+			.pinned(replicaBoard.get().isPinned())
+			.createdAt(replicaBoard.get().getCreatedAt())
+			.updated(replicaBoard.get().isUpdated())
+			.imageUrls(replicaBoard.get().getImageUrls())
+			.commentCount(replicaBoard.get().getCommentCount())
+			.likeCount(replicaBoard.get().getLikeCount())
 			.writerName(writerName)
 			.writerProfileImageUrl(writerProfileImageUrl)
 			.build();

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -5,6 +5,7 @@ import static hobbiedo.global.api.code.status.ErrorStatus.*;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.board.domain.ReplicaBoard;
+import hobbiedo.board.dto.BoardDetailsResponseDto;
 import hobbiedo.board.infrastructure.ReplicaBoardRepository;
 import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
@@ -14,6 +15,7 @@ import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
 import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import hobbiedo.member.application.ReplicaMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,6 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 
 	private final ReplicaBoardRepository replicaBoardRepository;
+
+	// 회원 서비스 추가
+	private final ReplicaMemberService replicaMemberService;
 
 	/**
 	 * 게시글 CQRS 패턴을 통해 복제
@@ -244,5 +249,66 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 				.likeCount(replicaBoard.getLikeCount() - 1)
 				.build()
 		);
+	}
+
+	/**
+	 * 게시글 조회
+	 * @param boardId
+	 * @return
+	 */
+	@Override
+	public BoardDetailsResponseDto getBoard(Long boardId) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(boardId)
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		String writerName = replicaMemberService.getMemberName(replicaBoard.getWriterUuid());
+		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
+			replicaBoard.getWriterUuid());
+
+		return BoardDetailsResponseDto.builder()
+			.boardId(replicaBoard.getBoardId())
+			.crewId(replicaBoard.getCrewId())
+			.content(replicaBoard.getContent())
+			.writerUuid(replicaBoard.getWriterUuid())
+			.pinned(replicaBoard.isPinned())
+			.createdAt(replicaBoard.getCreatedAt())
+			.updated(replicaBoard.isUpdated())
+			.imageUrls(replicaBoard.getImageUrls())
+			.commentCount(replicaBoard.getCommentCount())
+			.likeCount(replicaBoard.getLikeCount())
+			.writerName(writerName)
+			.writerProfileImageUrl(writerProfileImageUrl)
+			.build();
+	}
+
+	/**
+	 * 한 소모임의 최신 게시글 조회
+	 * @param crewId
+	 */
+	@Override
+	public BoardDetailsResponseDto getLatestBoard(Long crewId) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findTopByCrewIdOrderByBoardIdDesc(crewId)
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND_IN_CREW));
+
+		String writerName = replicaMemberService.getMemberName(replicaBoard.getWriterUuid());
+		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
+			replicaBoard.getWriterUuid());
+
+		return BoardDetailsResponseDto.builder()
+			.boardId(replicaBoard.getBoardId())
+			.crewId(replicaBoard.getCrewId())
+			.content(replicaBoard.getContent())
+			.writerUuid(replicaBoard.getWriterUuid())
+			.pinned(replicaBoard.isPinned())
+			.createdAt(replicaBoard.getCreatedAt())
+			.updated(replicaBoard.isUpdated())
+			.imageUrls(replicaBoard.getImageUrls())
+			.commentCount(replicaBoard.getCommentCount())
+			.likeCount(replicaBoard.getLikeCount())
+			.writerName(writerName)
+			.writerProfileImageUrl(writerProfileImageUrl)
+			.build();
 	}
 }

--- a/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
@@ -31,15 +31,12 @@ public class ReplicaBoard {
 	private List<String> imageUrls;
 	private Integer likeCount;
 	private Integer commentCount;
-	private String profileImageUrl;
-	private String writerName;
 
 	@Builder
 	public ReplicaBoard(String id, Long boardId, Long crewId, String content, String writerUuid,
 		boolean pinned,
 		LocalDateTime createdAt, boolean updated, List<String> imageUrls, Integer likeCount,
-		Integer commentCount,
-		String profileImageUrl, String writerName) {
+		Integer commentCount) {
 		this.id = id;
 		this.boardId = boardId;
 		this.crewId = crewId;
@@ -51,7 +48,5 @@ public class ReplicaBoard {
 		this.imageUrls = imageUrls;
 		this.likeCount = likeCount;
 		this.commentCount = commentCount;
-		this.profileImageUrl = profileImageUrl;
-		this.writerName = writerName;
 	}
 }

--- a/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
@@ -1,0 +1,29 @@
+package hobbiedo.board.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDetailsResponseDto {
+
+	private Long boardId;
+	private Long crewId;
+	private String content;
+	private String writerUuid;
+	private boolean pinned;
+	private LocalDateTime createdAt;
+	private boolean updated;
+	private List<String> imageUrls;
+	private Integer likeCount;
+	private Integer commentCount;
+	private String writerName;
+	private String writerProfileImageUrl;
+}

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
@@ -11,4 +11,7 @@ public interface ReplicaBoardRepository extends MongoRepository<ReplicaBoard, St
 	void deleteByBoardId(Long boardId);
 
 	Optional<ReplicaBoard> findByBoardId(Long boardId);
+
+	// crewId로 가장 최근에 작성된 board 를 가져옴
+	Optional<ReplicaBoard> findTopByCrewIdOrderByBoardIdDesc(Long crewId);
 }

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaBoardRepository.java
@@ -14,4 +14,6 @@ public interface ReplicaBoardRepository extends MongoRepository<ReplicaBoard, St
 
 	// crewId로 가장 최근에 작성된 board 를 가져옴
 	Optional<ReplicaBoard> findTopByCrewIdOrderByBoardIdDesc(Long crewId);
+
+	Optional<ReplicaBoard> findByPinnedTrueAndCrewId(Long crewId);
 }

--- a/src/main/java/hobbiedo/board/presentation/BoardController.java
+++ b/src/main/java/hobbiedo/board/presentation/BoardController.java
@@ -52,4 +52,25 @@ public class BoardController {
 			LatestBoardDetailsResponseVo.boardDtoToLatestDetailsVo(boardResponseDto)
 		);
 	}
+
+	// 고정 게시글 조회
+	@GetMapping("/{crewId}/pinned")
+	@Operation(summary = "고정 게시글 조회", description = "해당 소모임의 고정 게시글을 조회합니다.")
+	public ApiResponse<BoardDetailsResponseVo> getPinnedPost(
+		@PathVariable("crewId") Long crewId) {
+
+		BoardDetailsResponseDto boardResponseDto = replicaBoardService.getPinnedBoard(crewId);
+
+		if (boardResponseDto == null) {
+			return ApiResponse.onSuccess(
+				SuccessStatus.GET_PINNED_BOARD_SUCCESS,
+				null
+			);
+		}
+
+		return ApiResponse.onSuccess(
+			SuccessStatus.GET_PINNED_BOARD_SUCCESS,
+			BoardDetailsResponseVo.boardDtoToDetailsVo(boardResponseDto)
+		);
+	}
 }

--- a/src/main/java/hobbiedo/board/presentation/BoardController.java
+++ b/src/main/java/hobbiedo/board/presentation/BoardController.java
@@ -1,0 +1,55 @@
+package hobbiedo.board.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.dto.BoardDetailsResponseDto;
+import hobbiedo.board.vo.BoardDetailsResponseVo;
+import hobbiedo.board.vo.LatestBoardDetailsResponseVo;
+import hobbiedo.global.api.ApiResponse;
+import hobbiedo.global.api.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users/crew/board")
+@Tag(name = "Board", description = "소모임 게시판 서비스")
+public class BoardController {
+
+	private final ReplicaBoardService replicaBoardService;
+
+	// 게시글 상세 조회
+	@GetMapping("/{boardId}")
+	@Operation(summary = "게시글 상세 조회", description = "게시글을 상세 조회합니다.")
+	public ApiResponse<BoardDetailsResponseVo> getPost(
+		@PathVariable("boardId") Long boardId) {
+
+		BoardDetailsResponseDto boardResponseDto = replicaBoardService.getBoard(boardId);
+
+		return ApiResponse.onSuccess(
+			SuccessStatus.GET_BOARD_SUCCESS,
+			BoardDetailsResponseVo.boardDtoToDetailsVo(boardResponseDto)
+		);
+	}
+
+	// 한 소모임의 최신 게시글 조회
+	@GetMapping("/{crewId}/latest-board")
+	@Operation(summary = "소모임 최신 게시글 조회", description = "소모임의 최신 게시글을 조회합니다.")
+	public ApiResponse<LatestBoardDetailsResponseVo> getLatestPost(
+		@PathVariable("crewId") Long crewId) {
+
+		BoardDetailsResponseDto boardResponseDto = replicaBoardService.getLatestBoard(crewId);
+
+		return ApiResponse.onSuccess(
+			SuccessStatus.GET_LATEST_BOARD_SUCCESS,
+			LatestBoardDetailsResponseVo.boardDtoToLatestDetailsVo(boardResponseDto)
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
@@ -1,0 +1,66 @@
+package hobbiedo.board.vo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import hobbiedo.board.dto.BoardDetailsResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "게시글 조회 응답")
+public class BoardDetailsResponseVo {
+
+	private Long boardId;
+	private Long crewId;
+	private String content;
+	private String writerUuid;
+	private String writerName;
+	private String writerProfileImageUrl;
+	private boolean pinned;
+	private LocalDateTime createdAt;
+	private boolean updated;
+	private List<String> imageUrls;
+	private Integer likeCount;
+	private Integer commentCount;
+
+	public BoardDetailsResponseVo(Long boardId, Long crewId, String content,
+		String writerUuid,
+		boolean pinned, LocalDateTime createdAt, boolean updated, List<String> imageUrls,
+		Integer likeCount,
+		Integer commentCount, String writerName, String writerProfileImageUrl) {
+		this.boardId = boardId;
+		this.crewId = crewId;
+		this.content = content;
+		this.writerUuid = writerUuid;
+		this.pinned = pinned;
+		this.createdAt = createdAt;
+		this.updated = updated;
+		this.imageUrls = imageUrls;
+		this.likeCount = likeCount;
+		this.commentCount = commentCount;
+		this.writerName = writerName;
+		this.writerProfileImageUrl = writerProfileImageUrl;
+	}
+
+	public static BoardDetailsResponseVo boardDtoToDetailsVo(
+		BoardDetailsResponseDto boardResponseDto) {
+
+		return new BoardDetailsResponseVo(
+			boardResponseDto.getBoardId(),
+			boardResponseDto.getCrewId(),
+			boardResponseDto.getContent(),
+			boardResponseDto.getWriterUuid(),
+			boardResponseDto.isPinned(),
+			boardResponseDto.getCreatedAt(),
+			boardResponseDto.isUpdated(),
+			boardResponseDto.getImageUrls(),
+			boardResponseDto.getLikeCount(),
+			boardResponseDto.getCommentCount(),
+			boardResponseDto.getWriterName(),
+			boardResponseDto.getWriterProfileImageUrl()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
@@ -1,0 +1,60 @@
+package hobbiedo.board.vo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import hobbiedo.board.dto.BoardDetailsResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "게시글 조회 응답")
+public class LatestBoardDetailsResponseVo {
+
+	private Long boardId;
+	private Long crewId;
+	private String content;
+	private String writerUuid;
+	private String writerName;
+	private String writerProfileImageUrl;
+	private LocalDateTime createdAt;
+	private String thumbnailImageUrl;
+	private Integer likeCount;
+	private Integer commentCount;
+
+	public LatestBoardDetailsResponseVo(Long boardId, Long crewId, String content,
+		String writerUuid,
+		LocalDateTime createdAt, List<String> imageUrls, Integer likeCount,
+		Integer commentCount, String writerName, String writerProfileImageUrl) {
+		this.boardId = boardId;
+		this.crewId = crewId;
+		this.content = content;
+		this.writerUuid = writerUuid;
+		this.createdAt = createdAt;
+		this.thumbnailImageUrl =
+			(imageUrls != null && !imageUrls.isEmpty()) ? imageUrls.get(0) : null;
+		this.likeCount = likeCount;
+		this.commentCount = commentCount;
+		this.writerName = writerName;
+		this.writerProfileImageUrl = writerProfileImageUrl;
+	}
+
+	public static LatestBoardDetailsResponseVo boardDtoToLatestDetailsVo(
+		BoardDetailsResponseDto boardResponseDto) {
+
+		return new LatestBoardDetailsResponseVo(
+			boardResponseDto.getBoardId(),
+			boardResponseDto.getCrewId(),
+			boardResponseDto.getContent(),
+			boardResponseDto.getWriterUuid(),
+			boardResponseDto.getCreatedAt(),
+			boardResponseDto.getImageUrls(),
+			boardResponseDto.getLikeCount(),
+			boardResponseDto.getCommentCount(),
+			boardResponseDto.getWriterName(),
+			boardResponseDto.getWriterProfileImageUrl()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
@@ -1,6 +1,7 @@
 package hobbiedo.board.vo;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import hobbiedo.board.dto.BoardDetailsResponseDto;
@@ -20,21 +21,20 @@ public class LatestBoardDetailsResponseVo {
 	private String writerName;
 	private String writerProfileImageUrl;
 	private LocalDateTime createdAt;
-	private String thumbnailImageUrl;
+	private List<String> thumbnailUrl;
 	private Integer likeCount;
 	private Integer commentCount;
 
 	public LatestBoardDetailsResponseVo(Long boardId, Long crewId, String content,
 		String writerUuid,
-		LocalDateTime createdAt, List<String> imageUrls, Integer likeCount,
+		LocalDateTime createdAt, List<String> thumbnailUrl, Integer likeCount,
 		Integer commentCount, String writerName, String writerProfileImageUrl) {
 		this.boardId = boardId;
 		this.crewId = crewId;
 		this.content = content;
 		this.writerUuid = writerUuid;
 		this.createdAt = createdAt;
-		this.thumbnailImageUrl =
-			(imageUrls != null && !imageUrls.isEmpty()) ? imageUrls.get(0) : null;
+		this.thumbnailUrl = thumbnailUrl;
 		this.likeCount = likeCount;
 		this.commentCount = commentCount;
 		this.writerName = writerName;
@@ -44,13 +44,19 @@ public class LatestBoardDetailsResponseVo {
 	public static LatestBoardDetailsResponseVo boardDtoToLatestDetailsVo(
 		BoardDetailsResponseDto boardResponseDto) {
 
+		List<String> thumbnailUrl = new ArrayList<>();
+
+		if (!boardResponseDto.getImageUrls().isEmpty()) {
+			thumbnailUrl.add(boardResponseDto.getImageUrls().get(0));
+		}
+
 		return new LatestBoardDetailsResponseVo(
 			boardResponseDto.getBoardId(),
 			boardResponseDto.getCrewId(),
 			boardResponseDto.getContent(),
 			boardResponseDto.getWriterUuid(),
 			boardResponseDto.getCreatedAt(),
-			boardResponseDto.getImageUrls(),
+			thumbnailUrl,
 			boardResponseDto.getLikeCount(),
 			boardResponseDto.getCommentCount(),
 			boardResponseDto.getWriterName(),

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -16,8 +16,14 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 게시글 조회 에러
 	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다."),
 
+	// 아직 소모임에 게시글이 없는 경우
+	BOARD_NOT_FOUND_IN_CREW(HttpStatus.NOT_FOUND, "BOARD402", "소모임에 게시글이 없습니다."),
+
 	// MemberProfile
-	NOT_FOUND_MEMBER_PROFILE(HttpStatus.NOT_FOUND, "MEMBER401", "회원 프로필을 찾을 수 없습니다."),;
+	NOT_FOUND_MEMBER_PROFILE(HttpStatus.NOT_FOUND, "MEMBER401", "회원 프로필을 찾을 수 없습니다."),
+
+	// 회원 이미지 조회 에러
+	NOT_FOUND_MEMBER_PROFILE_IMAGE(HttpStatus.NOT_FOUND, "MEMBER402", "회원 프로필 이미지를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -10,7 +10,13 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessStatus implements BaseCode {
-	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다.");
+	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다."),
+
+	// 게시글 조회 성공
+	GET_BOARD_SUCCESS(HttpStatus.OK, "200", "게시글 조회 성공"),
+
+	// 해당 소모임의 최신 게시글 조회 성공
+	GET_LATEST_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 최신 게시글 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -16,7 +16,10 @@ public enum SuccessStatus implements BaseCode {
 	GET_BOARD_SUCCESS(HttpStatus.OK, "200", "게시글 조회 성공"),
 
 	// 해당 소모임의 최신 게시글 조회 성공
-	GET_LATEST_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 최신 게시글 조회 성공");
+	GET_LATEST_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 최신 게시글 조회 성공"),
+
+	// 해당 소모임의 고정 게시글 조회 성공
+	GET_PINNED_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 고정 게시글 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -62,7 +62,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> createKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCreateEventDto> createKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardCreateEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -86,7 +87,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> deleteKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardDeleteEventDto> deleteKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardDeleteEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -110,7 +112,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> updateKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardUpdateEventDto> updateKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardUpdateEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -134,7 +137,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> pinKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardPinEventDto> pinKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardPinEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -158,7 +162,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> unpinKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardUnPinEventDto> unpinKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardUnPinEventDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -182,7 +187,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> commentCountUpdateKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentCountUpdateDto> commentCountUpdateKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -206,7 +212,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> commentCountDeleteKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentCountUpdateDto> commentCountDeleteKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -230,7 +237,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> likeCountUpdateKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardLikeCountUpdateDto> likeCountUpdateKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();
@@ -254,7 +262,8 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> likeCountDeleteKafkaListenerContainerFactory() {
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardLikeCountUpdateDto> likeCountDeleteKafkaListenerContainerFactory() {
 
 		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
 			new ConcurrentKafkaListenerContainerFactory<>();

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberService.java
@@ -7,4 +7,8 @@ public interface ReplicaMemberService {
 	void createMemberProfile(SignUpDTO signUpDTO);
 
 	void updateMemberProfile(ModifyProfileDTO modifyProfileDTO);
+
+	String getMemberName(String writerUuid);
+
+	String getMemberProfileImageUrl(String writerUuid);
 }

--- a/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
+++ b/src/main/java/hobbiedo/member/application/ReplicaMemberServiceImp.java
@@ -26,4 +26,30 @@ public class ReplicaMemberServiceImp implements ReplicaMemberService {
 			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE));
 		replicaMemberRepository.save(modifyProfileDTO.toEntity(memberProfile));
 	}
+
+	/**
+	 * 회원 이름 조회
+	 * @param writerUuid
+	 * @return
+	 */
+	@Override
+	public String getMemberName(String writerUuid) {
+
+		return replicaMemberRepository.findByUuid(writerUuid)
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE))
+			.getName();
+	}
+
+	/**
+	 * 회원 프로필 이미지 조회
+	 * @param writerUuid
+	 * @return
+	 */
+	@Override
+	public String getMemberProfileImageUrl(String writerUuid) {
+
+		return replicaMemberRepository.findByUuid(writerUuid)
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE_IMAGE))
+			.getProfileUrl();
+	}
 }


### PR DESCRIPTION
## 📣 읽기 전용 게시글 조회 기능 추가 
### 📅 날짜 -  2024.06.22

### 🌵Branch
feature/cqrs-board-retrieval  → develop

### 📢 Description
**1. 소모임 게시판에서 게시글 상세 조회를 할 수 있다**
**2. 소모임 게시판에서 해당 게시판의 고정돤 게시글 상세 조회를 할 수 있다**
**3. 홈 에서 보여지는 활동이 활발한 소모임들의 최신 게시글의 상세 조회를 할 수 있다**

### 💬Issue Number
[#10 ] - 💫[FEAT] 읽기 전용 게시글 조회 기능 추가 #10

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 와 Mongo DB Compass, MySQL Workbench 를 통해 게시글들이 한 api 를 통해 모든 정보가 조회되는 것을 확인하였다