### PR TITLE
[FEAT] 게시글 댓글 CQRS 테이블 생성 및 삭제 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import hobbiedo.board.domain.ReplicaBoard;
 import hobbiedo.board.dto.BoardDetailsResponseDto;
 import hobbiedo.board.infrastructure.ReplicaBoardRepository;
+import hobbiedo.board.infrastructure.ReplicaCommentRepository;
 import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 
 	private final ReplicaBoardRepository replicaBoardRepository;
+	private final ReplicaCommentRepository replicaCommentRepository;
 
 	// 회원 서비스 추가
 	private final ReplicaMemberService replicaMemberService;
@@ -62,6 +64,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 	public void deleteReplicaBoard(BoardDeleteEventDto eventDto) {
 
 		replicaBoardRepository.deleteByBoardId(eventDto.getBoardId());
+
+		// 삭제된 게시글의 댓글 삭제
+		replicaCommentRepository.deleteByBoardId(eventDto.getBoardId());
 	}
 
 	/**

--- a/src/main/java/hobbiedo/board/application/ReplicaCommentService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaCommentService.java
@@ -1,0 +1,11 @@
+package hobbiedo.board.application;
+
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
+
+public interface ReplicaCommentService {
+
+	void createReplicaComment(BoardCommentUpdateDto eventDto);
+
+	void deleteReplicaComment(BoardCommentDeleteDto eventDto);
+}

--- a/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
@@ -1,0 +1,51 @@
+package hobbiedo.board.application;
+
+import org.springframework.stereotype.Service;
+
+import hobbiedo.board.domain.ReplicaComment;
+import hobbiedo.board.infrastructure.ReplicaCommentRepository;
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
+import hobbiedo.member.application.ReplicaMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReplicaCommentServiceImpl implements ReplicaCommentService {
+
+	private final ReplicaCommentRepository replicaCommentRepository;
+
+	// 회원 서비스 추가
+	private final ReplicaMemberService replicaMemberService;
+
+	/**
+	 * 게시글 댓글 CQRS 패턴을 통해 복제
+	 * @param eventDto
+	 */
+	@Override
+	public void createReplicaComment(BoardCommentUpdateDto eventDto) {
+
+		replicaCommentRepository.save(
+			ReplicaComment.builder()
+				.boardId(eventDto.getBoardId())
+				.commentId(eventDto.getCommentId())
+				.writerUuid(eventDto.getWriterUuid())
+				.content(eventDto.getContent())
+				.isInCrew(eventDto.getIsInCrew())
+				.createdAt(eventDto.getCreatedAt())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 댓글 CQRS 패턴을 통해 삭제
+	 * @param eventDto
+	 */
+	@Override
+	public void deleteReplicaComment(BoardCommentDeleteDto eventDto) {
+
+		replicaCommentRepository.deleteByCommentId(eventDto.getCommentId());
+	}
+}

--- a/src/main/java/hobbiedo/board/domain/ReplicaComment.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaComment.java
@@ -1,0 +1,41 @@
+package hobbiedo.board.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nonapi.io.github.classgraph.json.Id;
+
+@Document(collection = "replica_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReplicaComment {
+
+	@Id
+	private String id;
+	private Long boardId; // 게시글 번호
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
+
+	@Builder
+	public ReplicaComment(String id, Long boardId, Long commentId, String writerUuid,
+		String content, Boolean isInCrew, LocalDateTime createdAt) {
+		this.id = id;
+		this.boardId = boardId;
+		this.commentId = commentId;
+		this.writerUuid = writerUuid;
+		this.content = content;
+		this.isInCrew = isInCrew;
+		this.createdAt = createdAt;
+	}
+}

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaCommentRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaCommentRepository.java
@@ -1,0 +1,12 @@
+package hobbiedo.board.infrastructure;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.board.domain.ReplicaComment;
+
+public interface ReplicaCommentRepository extends MongoRepository<ReplicaComment, String> {
+
+	void deleteByCommentId(Long commentId);
+
+	void deleteByBoardId(Long boardId);
+}

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -6,7 +6,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.application.ReplicaCommentService;
 import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
 import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
@@ -21,6 +24,7 @@ public class KafkaConsumerService {
 
 	private static final Logger log = LoggerFactory.getLogger(KafkaConsumerService.class);
 	private final ReplicaBoardService replicaBoardService;
+	private final ReplicaCommentService replicaCommentService;
 
 	/**
 	 * 게시글 생성 이벤트 수신
@@ -121,5 +125,27 @@ public class KafkaConsumerService {
 	public void listenToLikeCountDeleteTopic(BoardLikeCountUpdateDto eventDto) {
 
 		replicaBoardService.decreaseLikeCount(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 테이블 생성 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-comment-update-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentCreateKafkaListenerContainerFactory")
+	public void listenToCommentCreateTopic(BoardCommentUpdateDto eventDto) {
+
+		replicaCommentService.createReplicaComment(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 테이블 삭제 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "board-comment-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentDeleteKafkaListenerContainerFactory")
+	public void listenToCommentDeleteTopic(BoardCommentDeleteDto eventDto) {
+
+		replicaCommentService.deleteReplicaComment(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentDeleteDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentDeleteDto.java
@@ -1,0 +1,16 @@
+package hobbiedo.board.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentDeleteDto {
+
+	private Long boardId;
+	private Long commentId;
+}

--- a/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
+++ b/src/main/java/hobbiedo/board/kafka/dto/BoardCommentUpdateDto.java
@@ -1,0 +1,22 @@
+package hobbiedo.board.kafka.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardCommentUpdateDto {
+
+	private Long boardId; // 게시글 번호
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
+}

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -15,6 +15,8 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import hobbiedo.board.kafka.dto.BoardCommentCountUpdateDto;
+import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
+import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.board.kafka.dto.BoardCreateEventDto;
 import hobbiedo.board.kafka.dto.BoardDeleteEventDto;
 import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
@@ -269,6 +271,56 @@ public class KafkaBoardConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(likeCountDeleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 댓글 테이블 생성 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentUpdateDto> commentCreateConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentUpdateDto> commentCreateKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentCreateConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 댓글 테이블 삭제 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentDeleteDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentDeleteDto> commentDeleteConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentDeleteDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentDeleteDto> commentDeleteKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentDeleteDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentDeleteConsumerFactory());
 
 		return factory;
 	}


### PR DESCRIPTION
## 📣 게시글 댓글 CQRS 테이블 생성 및 삭제 기능 추가
### 📅 날짜 -  2024.06.22

### 🌵Branch
feature/add-comment-cqrs-table-create-delete  → develop

### 📢 Description
**1. 컨슈머로 받은 데이터 내 게시글 id 와 댓글 상세 데이터로 게시글 댓글 CQRS 테이블 생성한다**
**2. 컨슈머로 받은 데이터 내 게시글 id로 게시글 댓글 CQRS 테이블 삭제한다**

### 💬Issue Number
[#12 ] - 💫[FEAT] 게시글 댓글 CQRS 테이블 생성 및 삭제 기능 추가 #12

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 게시글 서비스에서 게시글 댓글이 생성 되거나 삭제 되면 해당 CQRS 테이블이 생성, 삭제 되는 것을 확인하였다
2. 게시글 서비스에서 게시글 댓글이 생성 되거나 삭제 되면 게시글 CQRS 테이블의 댓글 수가 업데이트 되는 것을 확인하였다
3. 게시글을 삭제하면 해당 게시글 id 의 모든 댓글 CQRS 테이블을 삭제하게끔 구현하였다