### PR TITLE
[FEAT] 한 소모임 회원들의 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
@@ -6,7 +6,7 @@ import hobbiedo.crew.dto.response.CrewMemberDTO;
 import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
 
 public interface ReplicaCrewService {
-	List<CrewMemberDTO> getCrewMembers(long crewId);
+	List<CrewMemberDTO> getCrewMembers(long crewId, String uuid);
 
 	void createCrew(CrewEntryExitDTO crewEntryExitDTO);
 

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
@@ -1,8 +1,13 @@
 package hobbiedo.crew.application;
 
+import java.util.List;
+
+import hobbiedo.crew.dto.response.CrewMemberDTO;
 import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
 
 public interface ReplicaCrewService {
+	List<CrewMemberDTO> getCrewMembers(long crewId);
+
 	void createCrew(CrewEntryExitDTO crewEntryExitDTO);
 
 	void addCrewMember(CrewEntryExitDTO crewEntryExitDTO);

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
@@ -1,0 +1,11 @@
+package hobbiedo.crew.application;
+
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
+
+public interface ReplicaCrewService {
+	void createCrew(CrewEntryExitDTO crewEntryExitDTO);
+
+	void addCrewMember(CrewEntryExitDTO crewEntryExitDTO);
+
+	void deleteCrewMember(CrewEntryExitDTO crewEntryExitDTO);
+}

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
@@ -1,0 +1,60 @@
+package hobbiedo.crew.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import hobbiedo.crew.domain.Crew;
+import hobbiedo.crew.domain.CrewMember;
+import hobbiedo.crew.infrastructure.ReplicaCrewRepository;
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
+import hobbiedo.global.api.code.status.ErrorStatus;
+import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
+import hobbiedo.member.domain.MemberProfile;
+import hobbiedo.member.infrastructure.ReplicaMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReplicaCrewServiceImp implements ReplicaCrewService {
+
+	private final ReplicaCrewRepository replicaCrewRepository;
+	private final ReplicaMemberRepository replicaMemberRepository;
+
+	@Override
+	public void createCrew(CrewEntryExitDTO crewEntryExitDTO) {
+		MemberProfile memberProfile = getMemberProfile(crewEntryExitDTO.getUuid());
+		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(memberProfile,
+			true); // crew 생성 때 소모임장 추가
+		replicaCrewRepository.save(crewEntryExitDTO.toCrewEntity(List.of(crewMember)));
+	}
+
+	@Override
+	public void addCrewMember(CrewEntryExitDTO crewEntryExitDTO) {
+		MemberProfile memberProfile = getMemberProfile(crewEntryExitDTO.getUuid());
+		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(memberProfile,
+			false); // crew 가입 때 소모임원 추가
+		Crew crew = getCrew(crewEntryExitDTO.getCrewId());
+		crew.getCrewMembers().add(crewMember);
+		replicaCrewRepository.save(crew);
+	}
+
+	@Override
+	public void deleteCrewMember(CrewEntryExitDTO crewEntryExitDTO) {
+		Crew crew = getCrew(crewEntryExitDTO.getCrewId());
+		crew.getCrewMembers()
+			.removeIf(crewMember -> crewMember.getUuid().equals(crewEntryExitDTO.getUuid()));
+		replicaCrewRepository.save(crew);
+	}
+
+	private MemberProfile getMemberProfile(String uuid) {
+		return replicaMemberRepository.findByUuid(uuid)
+			.orElseThrow(
+				() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_MEMBER_PROFILE));
+	}
+
+	private Crew getCrew(long crewId) {
+		return replicaCrewRepository.findByCrewId(crewId)
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_CREW));
+	}
+}

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import hobbiedo.crew.domain.Crew;
 import hobbiedo.crew.domain.CrewMember;
+import hobbiedo.crew.dto.response.CrewMemberDTO;
 import hobbiedo.crew.infrastructure.ReplicaCrewRepository;
 import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
 import hobbiedo.global.api.code.status.ErrorStatus;
@@ -20,6 +21,12 @@ public class ReplicaCrewServiceImp implements ReplicaCrewService {
 
 	private final ReplicaCrewRepository replicaCrewRepository;
 	private final ReplicaMemberRepository replicaMemberRepository;
+
+	@Override
+	public List<CrewMemberDTO> getCrewMembers(long crewId) {
+		Crew crew = getCrew(crewId);
+		return CrewMemberDTO.toDtoList(crew.getCrewMembers());
+	}
 
 	@Override
 	public void createCrew(CrewEntryExitDTO crewEntryExitDTO) {

--- a/src/main/java/hobbiedo/crew/domain/Crew.java
+++ b/src/main/java/hobbiedo/crew/domain/Crew.java
@@ -1,0 +1,31 @@
+package hobbiedo.crew.domain;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "replica_crew")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Crew {
+	@Id
+	private String id;
+	private long crewId;
+	private List<CrewMember> crewMembers;
+
+	@Builder
+	public Crew(String id, long crewId, List<CrewMember> crewMembers) {
+		this.id = id;
+		this.crewId = crewId;
+		this.crewMembers = crewMembers;
+	}
+}

--- a/src/main/java/hobbiedo/crew/domain/CrewMember.java
+++ b/src/main/java/hobbiedo/crew/domain/CrewMember.java
@@ -1,0 +1,27 @@
+package hobbiedo.crew.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CrewMember {
+
+	private String uuid;
+	private String name;
+	private String profileUrl;
+	private boolean hostStatus;
+
+	@Builder
+	public CrewMember(String uuid, String name, String profileUrl, boolean hostStatus) {
+		this.uuid = uuid;
+		this.name = name;
+		this.profileUrl = profileUrl;
+		this.hostStatus = hostStatus;
+	}
+}

--- a/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
+++ b/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
@@ -1,0 +1,27 @@
+package hobbiedo.crew.dto.response;
+
+import java.util.List;
+
+import hobbiedo.crew.domain.CrewMember;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CrewMemberDTO {
+	private String uuid;
+	private String name;
+	private String profileUrl;
+	private boolean hostStatus;
+
+	public static List<CrewMemberDTO> toDtoList(List<CrewMember> crewMembers) {
+		return crewMembers.stream()
+			.map(crewMember -> CrewMemberDTO.builder()
+				.uuid(crewMember.getUuid())
+				.name(crewMember.getName())
+				.profileUrl(crewMember.getProfileUrl())
+				.hostStatus(crewMember.isHostStatus())
+				.build())
+			.toList();
+	}
+}

--- a/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
+++ b/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
@@ -1,7 +1,5 @@
 package hobbiedo.crew.dto.response;
 
-import java.util.List;
-
 import hobbiedo.crew.domain.CrewMember;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,16 +10,14 @@ public class CrewMemberDTO {
 	private String uuid;
 	private String name;
 	private String profileUrl;
-	private boolean hostStatus;
+	private int role; // 0:일반 소모임원, 1:소모임장, 2:나, 3:나 & 소모임장
 
-	public static List<CrewMemberDTO> toDtoList(List<CrewMember> crewMembers) {
-		return crewMembers.stream()
-			.map(crewMember -> CrewMemberDTO.builder()
-				.uuid(crewMember.getUuid())
-				.name(crewMember.getName())
-				.profileUrl(crewMember.getProfileUrl())
-				.hostStatus(crewMember.isHostStatus())
-				.build())
-			.toList();
+	public static CrewMemberDTO toDto(CrewMember crewMember, int role) {
+		return CrewMemberDTO.builder()
+			.uuid(crewMember.getUuid())
+			.name(crewMember.getName())
+			.profileUrl(crewMember.getProfileUrl())
+			.role(role)
+			.build();
 	}
 }

--- a/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
+++ b/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
@@ -1,0 +1,11 @@
+package hobbiedo.crew.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import hobbiedo.crew.domain.Crew;
+
+public interface ReplicaCrewRepository extends MongoRepository<Crew, String> {
+	Optional<Crew> findByCrewId(long crewId);
+}

--- a/src/main/java/hobbiedo/crew/kafka/application/KafkaCrewConsumerService.java
+++ b/src/main/java/hobbiedo/crew/kafka/application/KafkaCrewConsumerService.java
@@ -1,0 +1,37 @@
+package hobbiedo.crew.kafka.application;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import hobbiedo.crew.application.ReplicaCrewService;
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaCrewConsumerService {
+
+	private final ReplicaCrewService replicaCrewService;
+
+	// 소모임 생성 이벤트 수신 - crew 생성, crewMember 추가
+	@KafkaListener(topics = "create-crew-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "crewEntryExitKafkaListenerContainerFactory")
+	public void listenToCreateCrewTopic(CrewEntryExitDTO eventDto) {
+		replicaCrewService.createCrew(eventDto);
+	}
+
+	// 소모임 가입 이벤트 수신 - crewMember 추가
+	@KafkaListener(topics = "join-crew-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "crewEntryExitKafkaListenerContainerFactory")
+	public void listenToJoinCrewTopic(CrewEntryExitDTO eventDto) {
+		replicaCrewService.addCrewMember(eventDto);
+	}
+
+	// 소모임 탈퇴, 강퇴 이벤트 수신 - crewMember 삭제
+	@KafkaListener(topics = {"exit-crew-topic",
+		"force-exit-crew-topic"}, groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "crewEntryExitKafkaListenerContainerFactory")
+	public void listenToExitCrewTopic(CrewEntryExitDTO eventDto) {
+		replicaCrewService.deleteCrewMember(eventDto);
+	}
+}

--- a/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
+++ b/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
@@ -1,0 +1,34 @@
+package hobbiedo.crew.kafka.dto;
+
+import java.util.List;
+
+import hobbiedo.crew.domain.Crew;
+import hobbiedo.crew.domain.CrewMember;
+import hobbiedo.member.domain.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CrewEntryExitDTO {
+	private long crewId;
+	private String uuid;
+
+	public CrewMember toCrewMemberEntity(MemberProfile memberProfile, boolean hostStatus) {
+		return CrewMember.builder()
+			.uuid(uuid)
+			.name(memberProfile.getName())
+			.profileUrl(memberProfile.getProfileUrl())
+			.hostStatus(hostStatus)
+			.build();
+	}
+
+	public Crew toCrewEntity(List<CrewMember> crewMembers) {
+		return Crew.builder()
+			.crewId(crewId)
+			.crewMembers(crewMembers)
+			.build();
+	}
+}

--- a/src/main/java/hobbiedo/crew/presentation/CrewController.java
+++ b/src/main/java/hobbiedo/crew/presentation/CrewController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,9 +26,10 @@ public class CrewController {
 
 	@Operation(summary = "소모임 회원들의 프로필 목록 조회", description = "한 소모임 회원들의 프로필을 조회한다.")
 	@GetMapping("/crew/member/profiles/{crewId}")
-	public ApiResponse<List<CrewMemberDTO>> getCrewMembersProfile(@PathVariable long crewId) {
+	public ApiResponse<List<CrewMemberDTO>> getCrewMembersProfile(@PathVariable long crewId,
+		@RequestHeader(name = "Uuid") String uuid) {
 		return ApiResponse.onSuccess(SuccessStatus.GET_CREW_MEMBERS_PROFILE,
-			crewService.getCrewMembers(crewId));
+			crewService.getCrewMembers(crewId, uuid));
 	}
 
 }

--- a/src/main/java/hobbiedo/crew/presentation/CrewController.java
+++ b/src/main/java/hobbiedo/crew/presentation/CrewController.java
@@ -1,0 +1,33 @@
+package hobbiedo.crew.presentation;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hobbiedo.crew.application.ReplicaCrewService;
+import hobbiedo.crew.dto.response.CrewMemberDTO;
+import hobbiedo.global.api.ApiResponse;
+import hobbiedo.global.api.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users")
+@Tag(name = "Crew", description = "소모임 서비스")
+public class CrewController {
+
+	private final ReplicaCrewService crewService;
+
+	@Operation(summary = "소모임 회원들의 프로필 목록 조회", description = "한 소모임 회원들의 프로필을 조회한다.")
+	@GetMapping("/crew/member/profiles/{crewId}")
+	public ApiResponse<List<CrewMemberDTO>> getCrewMembersProfile(@PathVariable long crewId) {
+		return ApiResponse.onSuccess(SuccessStatus.GET_CREW_MEMBERS_PROFILE,
+			crewService.getCrewMembers(crewId));
+	}
+
+}

--- a/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/ErrorStatus.java
@@ -13,17 +13,19 @@ public enum ErrorStatus implements BaseErrorCode {
 	VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "GLOBAL400", "데이터베이스 유효성 에러"),
 	EXAMPLE_EXCEPTION(HttpStatus.BAD_REQUEST, "EXAMPLE400", "샘플 에러 메시지입니다"),
 
+	/* board */
 	// 게시글 조회 에러
 	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD401", "게시글을 찾을 수 없습니다."),
-
 	// 아직 소모임에 게시글이 없는 경우
 	BOARD_NOT_FOUND_IN_CREW(HttpStatus.NOT_FOUND, "BOARD402", "소모임에 게시글이 없습니다."),
 
-	// MemberProfile
+	/* MemberProfile */
 	NOT_FOUND_MEMBER_PROFILE(HttpStatus.NOT_FOUND, "MEMBER401", "회원 프로필을 찾을 수 없습니다."),
-
 	// 회원 이미지 조회 에러
-	NOT_FOUND_MEMBER_PROFILE_IMAGE(HttpStatus.NOT_FOUND, "MEMBER402", "회원 프로필 이미지를 찾을 수 없습니다.");
+	NOT_FOUND_MEMBER_PROFILE_IMAGE(HttpStatus.NOT_FOUND, "MEMBER402", "회원 프로필 이미지를 찾을 수 없습니다."),
+
+	/* Crew */
+	NOT_FOUND_CREW(HttpStatus.NOT_FOUND, "CREW401", "소모임을 찾을 수 없습니다."),;
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -12,14 +12,16 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessStatus implements BaseCode {
 	EXAMPLE_EXCEPTION(HttpStatus.OK, "EXAMPLE200", "샘플 성공 메시지입니다."),
 
+	/* BOARD */
 	// 게시글 조회 성공
 	GET_BOARD_SUCCESS(HttpStatus.OK, "200", "게시글 조회 성공"),
-
 	// 해당 소모임의 최신 게시글 조회 성공
 	GET_LATEST_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 최신 게시글 조회 성공"),
-
 	// 해당 소모임의 고정 게시글 조회 성공
-	GET_PINNED_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 고정 게시글 조회 성공");
+	GET_PINNED_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 고정 게시글 조회 성공"),
+
+	/* CREW */
+	GET_CREW_MEMBERS_PROFILE(HttpStatus.OK, "200", "소모임 회원들의 프로필 목록 조회에 성공하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String status;

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaCrewConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaCrewConsumerConfig.java
@@ -1,0 +1,65 @@
+package hobbiedo.global.config.consumer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import hobbiedo.crew.kafka.dto.CrewEntryExitDTO;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaCrewConsumerConfig {
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	private Map<String, Object> consumerConfigs() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지를 신뢰하도록 설정
+		return props;
+	}
+
+	/**
+	 * 소모임 생성 및 회원 입퇴장 컨슈머 팩토리
+	 * @return ConsumerFactory<String, EntryExitDTO>
+	 */
+	@Bean
+	public ConsumerFactory<String, CrewEntryExitDTO> crewEntryExitConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(CrewEntryExitDTO.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, CrewEntryExitDTO>
+		crewEntryExitKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, CrewEntryExitDTO> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(crewEntryExitConsumerFactory());
+
+		return factory;
+	}
+
+}


### PR DESCRIPTION
## 📣  [FEAT] 한 소모임 회원들의 프로필 조회 기능 구현
### 📅 2024.06.23

### 🌵Branch
feature/get-crew-member-profile → develop

### 📢 Description
소모임 생성, 가입 시에 read-only 데이터에 소모임 회원 프로필을 저장해 그 프로필을 조회하는 기능을 구현한다.

### 💬Issue Number
[#14] - [FEAT] 한 소모임 회원들의 프로필 조회 기능 구현

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
