### PR TITLE
[FEAT] 게시글 댓글 리스트 페이징 조회 기능 추가

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaCommentService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaCommentService.java
@@ -1,5 +1,8 @@
 package hobbiedo.board.application;
 
+import org.springframework.data.domain.Pageable;
+
+import hobbiedo.board.dto.CommentListResponseDto;
 import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
 import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 
@@ -8,4 +11,6 @@ public interface ReplicaCommentService {
 	void createReplicaComment(BoardCommentUpdateDto eventDto);
 
 	void deleteReplicaComment(BoardCommentDeleteDto eventDto);
+
+	CommentListResponseDto getCommentList(Long boardId, Pageable page);
 }

--- a/src/main/java/hobbiedo/board/dto/CommentListResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/CommentListResponseDto.java
@@ -1,0 +1,27 @@
+package hobbiedo.board.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentListResponseDto {
+
+	private Boolean isLast;
+	private List<CommentResponseDto> commentResponseDtoList;
+
+	public static CommentListResponseDto commentDtoToCommentListResponseDto(Boolean isLast,
+		List<CommentResponseDto> commentResponseDtoList) {
+
+		return CommentListResponseDto.builder()
+			.isLast(isLast)
+			.commentResponseDtoList(commentResponseDtoList)
+			.build();
+	}
+}

--- a/src/main/java/hobbiedo/board/dto/CommentResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/CommentResponseDto.java
@@ -1,0 +1,23 @@
+package hobbiedo.board.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponseDto {
+
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String writerName; // 작성자 이름
+	private String writerProfileImageUrl; // 작성자 프로필 이미지 url
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
+}

--- a/src/main/java/hobbiedo/board/infrastructure/ReplicaCommentRepository.java
+++ b/src/main/java/hobbiedo/board/infrastructure/ReplicaCommentRepository.java
@@ -1,5 +1,7 @@
 package hobbiedo.board.infrastructure;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import hobbiedo.board.domain.ReplicaComment;
@@ -9,4 +11,6 @@ public interface ReplicaCommentRepository extends MongoRepository<ReplicaComment
 	void deleteByCommentId(Long commentId);
 
 	void deleteByBoardId(Long boardId);
+
+	Page<ReplicaComment> findByBoardId(Long boardId, Pageable pageable);
 }

--- a/src/main/java/hobbiedo/board/presentation/BoardController.java
+++ b/src/main/java/hobbiedo/board/presentation/BoardController.java
@@ -1,13 +1,19 @@
 package hobbiedo.board.presentation;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hobbiedo.board.application.ReplicaBoardService;
+import hobbiedo.board.application.ReplicaCommentService;
 import hobbiedo.board.dto.BoardDetailsResponseDto;
+import hobbiedo.board.dto.CommentListResponseDto;
 import hobbiedo.board.vo.BoardDetailsResponseVo;
+import hobbiedo.board.vo.CommentListResponseVo;
 import hobbiedo.board.vo.LatestBoardDetailsResponseVo;
 import hobbiedo.global.api.ApiResponse;
 import hobbiedo.global.api.code.status.SuccessStatus;
@@ -24,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BoardController {
 
 	private final ReplicaBoardService replicaBoardService;
+	private final ReplicaCommentService boardInteractionService;
 
 	// 게시글 상세 조회
 	@GetMapping("/{boardId}")
@@ -71,6 +78,22 @@ public class BoardController {
 		return ApiResponse.onSuccess(
 			SuccessStatus.GET_PINNED_BOARD_SUCCESS,
 			BoardDetailsResponseVo.boardDtoToDetailsVo(boardResponseDto)
+		);
+	}
+
+	// 게시글 댓글 리스트 조회
+	@GetMapping("/{boardId}/comment-list")
+	@Operation(summary = "게시글 댓글 조회", description = "게시글에 등록된 댓글들을 조회합니다.")
+	public ApiResponse<CommentListResponseVo> getCommentList(
+		@PathVariable("boardId") Long boardId,
+		@PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable page) {
+
+		CommentListResponseDto commentListResponseDto = boardInteractionService.getCommentList(
+			boardId, page);
+
+		return ApiResponse.onSuccess(
+			SuccessStatus.GET_COMMENT_LIST_SUCCESS,
+			CommentListResponseVo.commentListToVo(commentListResponseDto)
 		);
 	}
 }

--- a/src/main/java/hobbiedo/board/vo/CommentListResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/CommentListResponseVo.java
@@ -1,0 +1,31 @@
+package hobbiedo.board.vo;
+
+import java.util.List;
+
+import hobbiedo.board.dto.CommentListResponseDto;
+import hobbiedo.board.dto.CommentResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "게시글 댓글 목록 조회 응답")
+public class CommentListResponseVo {
+
+	private Boolean isLast; // 마지막 페이지 여부
+	private List<CommentResponseVo> commentList; // 댓글 목록
+
+	public CommentListResponseVo(Boolean isLast, List<CommentResponseDto> commentList) {
+		this.isLast = isLast;
+		this.commentList = CommentResponseVo.commentDtoToCommentListResponseVo(commentList);
+	}
+
+	public static CommentListResponseVo commentListToVo(CommentListResponseDto commentListDto) {
+
+		return new CommentListResponseVo(
+			commentListDto.getIsLast(),
+			commentListDto.getCommentResponseDtoList()
+		);
+	}
+}

--- a/src/main/java/hobbiedo/board/vo/CommentResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/CommentResponseVo.java
@@ -1,0 +1,50 @@
+package hobbiedo.board.vo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import hobbiedo.board.dto.CommentResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "게시글 댓글 조회 응답")
+public class CommentResponseVo {
+
+	private Long commentId; // 댓글 번호
+	private String writerUuid; // 작성자 uuid
+	private String writerName;
+	private String writerProfileImageUrl;
+	private String content; // 댓글 내용
+	private Boolean isInCrew; // 소모임 회원 여부
+	private LocalDateTime createdAt; // 작성일
+
+	public CommentResponseVo(Long commentId, String writerUuid, String writerName,
+		String writerProfileImageUrl,
+		String content, Boolean isInCrew, LocalDateTime createdAt) {
+		this.commentId = commentId;
+		this.writerUuid = writerUuid;
+		this.writerName = writerName;
+		this.writerProfileImageUrl = writerProfileImageUrl;
+		this.content = content;
+		this.isInCrew = isInCrew;
+		this.createdAt = createdAt;
+	}
+
+	public static List<CommentResponseVo> commentDtoToCommentListResponseVo(
+		List<CommentResponseDto> commentResponseDtoList) {
+
+		return commentResponseDtoList.stream()
+			.map(commentResponseDto -> new CommentResponseVo(
+				commentResponseDto.getCommentId(),
+				commentResponseDto.getWriterUuid(),
+				commentResponseDto.getWriterName(),
+				commentResponseDto.getWriterProfileImageUrl(),
+				commentResponseDto.getContent(),
+				commentResponseDto.getIsInCrew(),
+				commentResponseDto.getCreatedAt()))
+			.toList();
+	}
+}

--- a/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
+++ b/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
@@ -3,9 +3,13 @@ package hobbiedo.crew.infrastructure;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import hobbiedo.crew.domain.Crew;
 
 public interface ReplicaCrewRepository extends MongoRepository<Crew, String> {
 	Optional<Crew> findByCrewId(long crewId);
+
+	@Query("{ 'crewId' : ?0, 'crewMembers.uuid' : ?1 }")
+	Optional<Boolean> existsByCrewIdAndMemberUuid(Long crewId, String uuid);
 }

--- a/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
+++ b/src/main/java/hobbiedo/global/api/code/status/SuccessStatus.java
@@ -19,6 +19,8 @@ public enum SuccessStatus implements BaseCode {
 	GET_LATEST_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 최신 게시글 조회 성공"),
 	// 해당 소모임의 고정 게시글 조회 성공
 	GET_PINNED_BOARD_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 고정 게시글 조회 성공"),
+	// 해당 소모임의 게시글 댓글 리스트 조회 성공
+	GET_COMMENT_LIST_SUCCESS(HttpStatus.OK, "200", "해당 소모임의 게시글 댓글 리스트 조회 성공"),
 
 	/* CREW */
 	GET_CREW_MEMBERS_PROFILE(HttpStatus.OK, "200", "소모임 회원들의 프로필 목록 조회에 성공하였습니다.");


### PR DESCRIPTION
## 📣 특정 게시글 댓글 리스트 페이징 조회 기능 추가
### 📅 날짜 -  2024.06.23

### 🌵Branch
feature/cqrs-comment-list-pagination  → develop

### 📢 Description
**특정 소모임의 댓글 리스트를 10개씩 페이징의 형태로 보여준다**

### 💬Issue Number
[#16 ] - 💫[FEAT] 게시글 댓글 리스트 페이징 조회 기능 추가 #16

### 🛠️Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 와 Mongo DB Explorer 를 통해 테스트를 진행하였고, 조회가 되는 것을 확인하였다
2. 해당 댓글 작성자의 해당 소모임의 소속 여부를 함께 조회가 되게끔 한다