### PR TITLE
[REFACTOR] 게시글 댓글 리스트 조회 시 검증 로직 수정

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
@@ -17,7 +17,6 @@ import hobbiedo.board.infrastructure.ReplicaCommentRepository;
 import hobbiedo.board.kafka.dto.BoardCommentDeleteDto;
 import hobbiedo.board.kafka.dto.BoardCommentUpdateDto;
 import hobbiedo.crew.infrastructure.ReplicaCrewRepository;
-import hobbiedo.global.api.code.status.ErrorStatus;
 import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
 import hobbiedo.member.application.ReplicaMemberService;
 import lombok.RequiredArgsConstructor;
@@ -74,7 +73,7 @@ public class ReplicaCommentServiceImpl implements ReplicaCommentService {
 	public CommentListResponseDto getCommentList(Long boardId, Pageable page) {
 
 		// 게시글이 존재하는지 확인
-		replicaBoardRepository.findById(String.valueOf(boardId))
+		replicaBoardRepository.findByBoardId(boardId)
 			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
 
 		Page<ReplicaComment> comments = replicaCommentRepository.findByBoardId(boardId, page);


### PR DESCRIPTION
## 📣 게시글 댓글 리스트 조회 시 검증 로직 수정
### 📅 날짜 -  2024.06.23

### 🌵Branch
feature/comment-list-verification-fix  → develop

### 📢 Description
**게시글 댓글 리스트 조회를 해당 게시글 CQRS 테이블의 Long 형 id 를 조회해야 하는데 해당 Mongo 테이블의 String 형 id 를 조회하면서 난 에러이므로 이 부분을 수정한다**

### 💬Issue Number
[#18 ] - ♻️[REFACTOR] 게시글 댓글 리스트 조회 시 검증 로직 수정 #18

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. Swagger 를 통해 테스트를 확인하였다