### PR TITLE
[REFACTOR] 게시글 댓글 작성자 소모임 소속 여부 조회 기능 수정

### DIFF
--- a/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +14,6 @@ import nonapi.io.github.classgraph.json.Id;
 @Document(collection = "replica_board")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReplicaBoard {
 
 	@Id

--- a/src/main/java/hobbiedo/board/domain/ReplicaComment.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaComment.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +13,6 @@ import nonapi.io.github.classgraph.json.Id;
 @Document(collection = "replica_comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReplicaComment {
 
 	@Id

--- a/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
@@ -48,6 +48,11 @@ public class BoardDetailsResponseVo {
 	public static BoardDetailsResponseVo boardDtoToDetailsVo(
 		BoardDetailsResponseDto boardResponseDto) {
 
+		List<String> imageUrls = boardResponseDto.getImageUrls();
+		if (imageUrls.isEmpty()) {
+			imageUrls = null;
+		}
+
 		return new BoardDetailsResponseVo(
 			boardResponseDto.getBoardId(),
 			boardResponseDto.getCrewId(),
@@ -56,7 +61,7 @@ public class BoardDetailsResponseVo {
 			boardResponseDto.isPinned(),
 			boardResponseDto.getCreatedAt(),
 			boardResponseDto.isUpdated(),
-			boardResponseDto.getImageUrls(),
+			imageUrls,
 			boardResponseDto.getLikeCount(),
 			boardResponseDto.getCommentCount(),
 			boardResponseDto.getWriterName(),

--- a/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
+++ b/src/main/java/hobbiedo/crew/infrastructure/ReplicaCrewRepository.java
@@ -10,6 +10,6 @@ import hobbiedo.crew.domain.Crew;
 public interface ReplicaCrewRepository extends MongoRepository<Crew, String> {
 	Optional<Crew> findByCrewId(long crewId);
 
-	@Query("{ 'crewId' : ?0, 'crewMembers.uuid' : ?1 }")
+	@Query("{ 'crewId' : ?0, 'crewMembers' : { $elemMatch: { 'uuid' : ?1 } } }")
 	Optional<Boolean> existsByCrewIdAndMemberUuid(Long crewId, String uuid);
 }


### PR DESCRIPTION
## 📣 게시글 댓글 작성자 소모임 소속 여부 조회 기능 수정
### 📅 날짜 - 2024.06.24

### 🌵Branch
feature/comment-writer-crew-membership-check-fix  → develop

### 📢 Description
**ReplicaCrewRepository 에서 해당 소모임 소속 회원들 중 댓글 작성자의 uuid 와 일치하는 것이 있는지 찾는 메소드의 쿼리를 수정한다**

### 💬Issue Number
[#20 ] - ♻️[REFACTOR] 게시글 댓글 작성자 소모임 소속 여부 조회 기능 수정 #20

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
**프론트 요청에 따라 소모임 내 게시글 객체 반환 필드 형식 수정하였다**