### PR TITLE
[REFACTOR] 게시글 좋아요 수, 댓글 수 업데이트 토픽 및 로직 변환

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardService.java
@@ -21,17 +21,13 @@ public interface ReplicaBoardService {
 
 	void unPinReplicaBoard(BoardUnPinEventDto eventDto);
 
-	void increaseCommentCount(BoardCommentCountUpdateDto eventDto);
-
-	void decreaseCommentCount(BoardCommentCountUpdateDto eventDto);
-
-	void increaseLikeCount(BoardLikeCountUpdateDto eventDto);
-
-	void decreaseLikeCount(BoardLikeCountUpdateDto eventDto);
-
 	BoardDetailsResponseDto getBoard(Long boardId);
 
 	BoardDetailsResponseDto getLatestBoard(Long crewId);
 
 	BoardDetailsResponseDto getPinnedBoard(Long crewId);
+
+	void changeCommentCount(BoardCommentCountUpdateDto eventDto);
+
+	void changeLikeCount(BoardLikeCountUpdateDto eventDto);
 }

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -151,114 +151,6 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 	}
 
 	/**
-	 * 게시글 댓글 수 증가
-	 * @param eventDto
-	 */
-	@Override
-	public void increaseCommentCount(BoardCommentCountUpdateDto eventDto) {
-
-		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
-			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
-
-		replicaBoardRepository.save(
-			ReplicaBoard.builder()
-				.id(replicaBoard.getId())
-				.boardId(replicaBoard.getBoardId())
-				.crewId(replicaBoard.getCrewId())
-				.content(replicaBoard.getContent())
-				.writerUuid(replicaBoard.getWriterUuid())
-				.pinned(replicaBoard.isPinned())
-				.createdAt(replicaBoard.getCreatedAt())
-				.updated(replicaBoard.isUpdated())
-				.imageUrls(replicaBoard.getImageUrls())
-				.commentCount(replicaBoard.getCommentCount() + 1)
-				.likeCount(replicaBoard.getLikeCount())
-				.build()
-		);
-	}
-
-	/**
-	 * 게시글 댓글 수 감소
-	 * @param eventDto
-	 */
-	@Override
-	public void decreaseCommentCount(BoardCommentCountUpdateDto eventDto) {
-
-		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
-			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
-
-		replicaBoardRepository.save(
-			ReplicaBoard.builder()
-				.id(replicaBoard.getId())
-				.boardId(replicaBoard.getBoardId())
-				.crewId(replicaBoard.getCrewId())
-				.content(replicaBoard.getContent())
-				.writerUuid(replicaBoard.getWriterUuid())
-				.pinned(replicaBoard.isPinned())
-				.createdAt(replicaBoard.getCreatedAt())
-				.updated(replicaBoard.isUpdated())
-				.imageUrls(replicaBoard.getImageUrls())
-				.commentCount(replicaBoard.getCommentCount() - 1)
-				.likeCount(replicaBoard.getLikeCount())
-				.build()
-		);
-	}
-
-	/**
-	 * 게시글 좋아요 수 증가
-	 * @param eventDto
-	 */
-	@Override
-	public void increaseLikeCount(BoardLikeCountUpdateDto eventDto) {
-
-		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
-			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
-
-		replicaBoardRepository.save(
-			ReplicaBoard.builder()
-				.id(replicaBoard.getId())
-				.boardId(replicaBoard.getBoardId())
-				.crewId(replicaBoard.getCrewId())
-				.content(replicaBoard.getContent())
-				.writerUuid(replicaBoard.getWriterUuid())
-				.pinned(replicaBoard.isPinned())
-				.createdAt(replicaBoard.getCreatedAt())
-				.updated(replicaBoard.isUpdated())
-				.imageUrls(replicaBoard.getImageUrls())
-				.commentCount(replicaBoard.getCommentCount())
-				.likeCount(replicaBoard.getLikeCount() + 1)
-				.build()
-		);
-	}
-
-	/**
-	 * 게시글 좋아요 수 감소
-	 * @param eventDto
-	 */
-	@Override
-	public void decreaseLikeCount(BoardLikeCountUpdateDto eventDto) {
-
-		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
-			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
-
-		replicaBoardRepository.save(
-			ReplicaBoard.builder()
-				.id(replicaBoard.getId())
-				.boardId(replicaBoard.getBoardId())
-				.crewId(replicaBoard.getCrewId())
-				.content(replicaBoard.getContent())
-				.writerUuid(replicaBoard.getWriterUuid())
-				.pinned(replicaBoard.isPinned())
-				.createdAt(replicaBoard.getCreatedAt())
-				.updated(replicaBoard.isUpdated())
-				.imageUrls(replicaBoard.getImageUrls())
-				.commentCount(replicaBoard.getCommentCount())
-				.likeCount(replicaBoard.getLikeCount() - 1)
-				.build()
-		);
-	}
-
-	/**
 	 * 게시글 조회
 	 * @param boardId
 	 * @return
@@ -352,5 +244,61 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 			.writerName(writerName)
 			.writerProfileImageUrl(writerProfileImageUrl)
 			.build();
+	}
+
+	/**
+	 * 게시글 댓글 수 변경
+	 * @param eventDto
+	 * @return
+	 */
+	@Override
+	public void changeCommentCount(BoardCommentCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount() + eventDto.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount())
+				.build()
+		);
+	}
+
+	/**
+	 * 게시글 좋아요 수 변경
+	 * @param eventDto
+	 * @return
+	 */
+	@Override
+	public void changeLikeCount(BoardLikeCountUpdateDto eventDto) {
+
+		ReplicaBoard replicaBoard = replicaBoardRepository.findByBoardId(eventDto.getBoardId())
+			.orElseThrow(() -> new ReadOnlyExceptionHandler(BOARD_NOT_FOUND));
+
+		replicaBoardRepository.save(
+			ReplicaBoard.builder()
+				.id(replicaBoard.getId())
+				.boardId(replicaBoard.getBoardId())
+				.crewId(replicaBoard.getCrewId())
+				.content(replicaBoard.getContent())
+				.writerUuid(replicaBoard.getWriterUuid())
+				.pinned(replicaBoard.isPinned())
+				.createdAt(replicaBoard.getCreatedAt())
+				.updated(replicaBoard.isUpdated())
+				.imageUrls(replicaBoard.getImageUrls())
+				.commentCount(replicaBoard.getCommentCount())
+				.likeCount(replicaBoard.getLikeCount() + eventDto.getLikeCount())
+				.build()
+		);
 	}
 }

--- a/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
+++ b/src/main/java/hobbiedo/board/kafka/application/KafkaConsumerService.java
@@ -84,50 +84,6 @@ public class KafkaConsumerService {
 	}
 
 	/**
-	 * 게시글 댓글 수 증가 이벤트 수신
-	 * @param eventDto
-	 */
-	@KafkaListener(topics = "statistics-board-comment-update-topic", groupId = "${spring.kafka.consumer.group-id}",
-		containerFactory = "commentCountUpdateKafkaListenerContainerFactory")
-	public void listenToCommentCountUpdateTopic(BoardCommentCountUpdateDto eventDto) {
-
-		replicaBoardService.increaseCommentCount(eventDto);
-	}
-
-	/**
-	 * 게시글 댓글 수 감소 이벤트 수신
-	 * @param eventDto
-	 */
-	@KafkaListener(topics = "statistics-board-comment-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
-		containerFactory = "commentCountDeleteKafkaListenerContainerFactory")
-	public void listenToCommentCountDeleteTopic(BoardCommentCountUpdateDto eventDto) {
-
-		replicaBoardService.decreaseCommentCount(eventDto);
-	}
-
-	/**
-	 * 게시글 좋아요 수 증가 이벤트 수신
-	 * @param eventDto
-	 */
-	@KafkaListener(topics = "statistics-board-like-update-topic", groupId = "${spring.kafka.consumer.group-id}",
-		containerFactory = "likeCountUpdateKafkaListenerContainerFactory")
-	public void listenToLikeCountUpdateTopic(BoardLikeCountUpdateDto eventDto) {
-
-		replicaBoardService.increaseLikeCount(eventDto);
-	}
-
-	/**
-	 * 게시글 좋아요 수 감소 이벤트 수신
-	 * @param eventDto
-	 */
-	@KafkaListener(topics = "statistics-board-like-delete-topic", groupId = "${spring.kafka.consumer.group-id}",
-		containerFactory = "likeCountDeleteKafkaListenerContainerFactory")
-	public void listenToLikeCountDeleteTopic(BoardLikeCountUpdateDto eventDto) {
-
-		replicaBoardService.decreaseLikeCount(eventDto);
-	}
-
-	/**
 	 * 게시글 댓글 테이블 생성 이벤트 수신
 	 * @param eventDto
 	 */
@@ -147,5 +103,27 @@ public class KafkaConsumerService {
 	public void listenToCommentDeleteTopic(BoardCommentDeleteDto eventDto) {
 
 		replicaCommentService.deleteReplicaComment(eventDto);
+	}
+
+	/**
+	 * 게시글 댓글 수 변경 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-comment-change-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "commentCountChangeKafkaListenerContainerFactory")
+	public void listenToCommentCountChangeTopic(BoardCommentCountUpdateDto eventDto) {
+
+		replicaBoardService.changeCommentCount(eventDto);
+	}
+
+	/**
+	 * 게시글 좋아요 수 변경 이벤트 수신
+	 * @param eventDto
+	 */
+	@KafkaListener(topics = "statistics-board-like-change-topic", groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "likeCountChangeKafkaListenerContainerFactory")
+	public void listenToLikeCountChangeTopic(BoardLikeCountUpdateDto eventDto) {
+
+		replicaBoardService.changeLikeCount(eventDto);
 	}
 }

--- a/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
+++ b/src/main/java/hobbiedo/global/config/consumer/KafkaBoardConsumerConfig.java
@@ -176,106 +176,6 @@ public class KafkaBoardConsumerConfig {
 	}
 
 	/**
-	 * 게시글 테이블 댓글 수 증가 이벤트용 ConsumerFactory
-	 * @return ConsumerFactory<String, BoardCommentCountUpdateDto>
-	 */
-	@Bean
-	public ConsumerFactory<String, BoardCommentCountUpdateDto> commentCountUpdateConsumerFactory() {
-
-		Map<String, Object> configProps = consumerConfigs();
-
-		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
-			new JsonDeserializer<>(BoardCommentCountUpdateDto.class, false));
-	}
-
-	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String,
-		BoardCommentCountUpdateDto> commentCountUpdateKafkaListenerContainerFactory() {
-
-		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
-			new ConcurrentKafkaListenerContainerFactory<>();
-
-		factory.setConsumerFactory(commentCountUpdateConsumerFactory());
-
-		return factory;
-	}
-
-	/**
-	 * 게시글 댓글 수 감소 이벤트용 ConsumerFactory
-	 * @return ConsumerFactory<String, BoardCommentCountUpdateDto>
-	 */
-	@Bean
-	public ConsumerFactory<String, BoardCommentCountUpdateDto> commentCountDeleteConsumerFactory() {
-
-		Map<String, Object> configProps = consumerConfigs();
-
-		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
-			new JsonDeserializer<>(BoardCommentCountUpdateDto.class, false));
-	}
-
-	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String,
-		BoardCommentCountUpdateDto> commentCountDeleteKafkaListenerContainerFactory() {
-
-		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
-			new ConcurrentKafkaListenerContainerFactory<>();
-
-		factory.setConsumerFactory(commentCountDeleteConsumerFactory());
-
-		return factory;
-	}
-
-	/**
-	 * 게시글 좋아요 수 증가 이벤트용 ConsumerFactory
-	 * @return ConsumerFactory<String, BoardLikeCountUpdateDto>
-	 */
-	@Bean
-	public ConsumerFactory<String, BoardLikeCountUpdateDto> likeCountUpdateConsumerFactory() {
-
-		Map<String, Object> configProps = consumerConfigs();
-
-		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
-			new JsonDeserializer<>(BoardLikeCountUpdateDto.class, false));
-	}
-
-	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String,
-		BoardLikeCountUpdateDto> likeCountUpdateKafkaListenerContainerFactory() {
-
-		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
-			new ConcurrentKafkaListenerContainerFactory<>();
-
-		factory.setConsumerFactory(likeCountUpdateConsumerFactory());
-
-		return factory;
-	}
-
-	/**
-	 * 게시글 좋아요 수 감소 이벤트용 ConsumerFactory
-	 * @return ConsumerFactory<String, BoardLikeCountUpdateDto>
-	 */
-	@Bean
-	public ConsumerFactory<String, BoardLikeCountUpdateDto> likeCountDeleteConsumerFactory() {
-
-		Map<String, Object> configProps = consumerConfigs();
-
-		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
-			new JsonDeserializer<>(BoardLikeCountUpdateDto.class, false));
-	}
-
-	@Bean
-	public ConcurrentKafkaListenerContainerFactory<String,
-		BoardLikeCountUpdateDto> likeCountDeleteKafkaListenerContainerFactory() {
-
-		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
-			new ConcurrentKafkaListenerContainerFactory<>();
-
-		factory.setConsumerFactory(likeCountDeleteConsumerFactory());
-
-		return factory;
-	}
-
-	/**
 	 * 게시글 댓글 테이블 생성 이벤트용 ConsumerFactory
 	 * @return ConsumerFactory<String, BoardCommentUpdateDto>
 	 */
@@ -321,6 +221,56 @@ public class KafkaBoardConsumerConfig {
 			new ConcurrentKafkaListenerContainerFactory<>();
 
 		factory.setConsumerFactory(commentDeleteConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 댓글 수 변경 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardCommentCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardCommentCountUpdateDto> commentCountChangeConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardCommentCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardCommentCountUpdateDto> commentCountChangeKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardCommentCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(commentCountChangeConsumerFactory());
+
+		return factory;
+	}
+
+	/**
+	 * 게시글 좋아요 수 변경 이벤트용 ConsumerFactory
+	 * @return ConsumerFactory<String, BoardLikeCountUpdateDto>
+	 */
+	@Bean
+	public ConsumerFactory<String, BoardLikeCountUpdateDto> likeCountChangeConsumerFactory() {
+
+		Map<String, Object> configProps = consumerConfigs();
+
+		return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(),
+			new JsonDeserializer<>(BoardLikeCountUpdateDto.class, false));
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String,
+		BoardLikeCountUpdateDto> likeCountChangeKafkaListenerContainerFactory() {
+
+		ConcurrentKafkaListenerContainerFactory<String, BoardLikeCountUpdateDto> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(likeCountChangeConsumerFactory());
 
 		return factory;
 	}


### PR DESCRIPTION
## 📣 게시글 좋아요 수, 댓글 수 업데이트 토픽 및 로직 변환
### 📅 날짜 -  2024.06.27

### 🌵Branch
refactor-like-comment-count  → develop

### 📢 Description
**배치 서비스에서 스프링 배치를 적용 전, 게시글의 댓글 및 좋아요에 대한 증가, 감소 토픽을 각각 따로 보내고, 이를 받았을 때 테이블에 +1 또는 -1 을 하던 것을 스프링 배치 적용 후, 하나의 변화 토픽을 받은 후 변환된 갯수 데이터를 한번에 업데이트 하게끔 수정하였다**

### 💬Issue Number
[#24 ] - ♻️[REFACTOR] 게시글 좋아요 수, 댓글 수 업데이트 토픽 및 로직 변환 #24

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 게시글 댓글 작성 시 댓글 CQRS 테이블은 바로 생성이 되고, 댓글 수나 좋아요 수는 변환 토픽을 감지하면 수정되는 것을 확인하였다