### PR TITLE
[REFACTOR] 읽기 전용 Mongo DB 내 날짜 저장 필드 형식 수정

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -2,6 +2,10 @@ package hobbiedo.board.application;
 
 import static hobbiedo.global.api.code.status.ErrorStatus.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -40,6 +44,15 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 	@Override
 	public void createReplicaBoard(BoardCreateEventDto eventDto) {
 
+		// 기존 LocalDateTime 객체
+		LocalDateTime localDateTime = eventDto.getCreatedAt();
+
+		// LocalDateTime 을 ZonedDateTime 으로 변환
+		ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("Asia/Seoul"));
+
+		// ZonedDateTime 을 Instant 로 변환
+		Instant instant = zonedDateTime.toInstant();
+
 		replicaBoardRepository.save(
 			ReplicaBoard.builder()
 				.boardId(eventDto.getBoardId())
@@ -47,7 +60,7 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 				.content(eventDto.getContent())
 				.writerUuid(eventDto.getWriterUuid())
 				.pinned(eventDto.isPinned())
-				.createdAt(eventDto.getCreatedAt())
+				.createdAt(instant)
 				.updated(eventDto.isUpdated())
 				.imageUrls(eventDto.getImageUrls())
 				.commentCount(0)

--- a/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaCommentServiceImpl.java
@@ -2,6 +2,10 @@ package hobbiedo.board.application;
 
 import static hobbiedo.global.api.code.status.ErrorStatus.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
 
@@ -42,6 +46,15 @@ public class ReplicaCommentServiceImpl implements ReplicaCommentService {
 	@Override
 	public void createReplicaComment(BoardCommentUpdateDto eventDto) {
 
+		// 기존 LocalDateTime 객체
+		LocalDateTime localDateTime = eventDto.getCreatedAt();
+
+		// LocalDateTime 을 ZonedDateTime 으로 변환
+		ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("Asia/Seoul"));
+
+		// ZonedDateTime 을 Instant 로 변환
+		Instant instant = zonedDateTime.toInstant();
+
 		replicaCommentRepository.save(
 			ReplicaComment.builder()
 				.boardId(eventDto.getBoardId())
@@ -49,7 +62,7 @@ public class ReplicaCommentServiceImpl implements ReplicaCommentService {
 				.writerUuid(eventDto.getWriterUuid())
 				.content(eventDto.getContent())
 				.isInCrew(eventDto.getIsInCrew())
-				.createdAt(eventDto.getCreatedAt())
+				.createdAt(instant)
 				.build()
 		);
 	}
@@ -105,7 +118,7 @@ public class ReplicaCommentServiceImpl implements ReplicaCommentService {
 		if (crewId == null) {
 			throw new ReadOnlyExceptionHandler(NOT_FOUND_CREW);
 		}
-		
+
 		return replicaCrewRepository.findCrewByCrewIdAndMemberUuid(crewId, writerUuid).isPresent();
 	}
 }

--- a/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaBoard.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.domain;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -23,7 +23,7 @@ public class ReplicaBoard {
 	private String content;
 	private String writerUuid;
 	private boolean pinned;
-	private LocalDateTime createdAt;
+	private Instant createdAt;
 	private boolean updated;
 	private List<String> imageUrls;
 	private Integer likeCount;
@@ -32,7 +32,7 @@ public class ReplicaBoard {
 	@Builder
 	public ReplicaBoard(String id, Long boardId, Long crewId, String content, String writerUuid,
 		boolean pinned,
-		LocalDateTime createdAt, boolean updated, List<String> imageUrls, Integer likeCount,
+		Instant createdAt, boolean updated, List<String> imageUrls, Integer likeCount,
 		Integer commentCount) {
 		this.id = id;
 		this.boardId = boardId;

--- a/src/main/java/hobbiedo/board/domain/ReplicaComment.java
+++ b/src/main/java/hobbiedo/board/domain/ReplicaComment.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.domain;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -22,11 +22,11 @@ public class ReplicaComment {
 	private String writerUuid; // 작성자 uuid
 	private String content; // 댓글 내용
 	private Boolean isInCrew; // 소모임 회원 여부
-	private LocalDateTime createdAt; // 작성일
+	private Instant createdAt; // 작성일
 
 	@Builder
 	public ReplicaComment(String id, Long boardId, Long commentId, String writerUuid,
-		String content, Boolean isInCrew, LocalDateTime createdAt) {
+		String content, Boolean isInCrew, Instant createdAt) {
 		this.id = id;
 		this.boardId = boardId;
 		this.commentId = commentId;

--- a/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -19,7 +19,7 @@ public class BoardDetailsResponseDto {
 	private String content;
 	private String writerUuid;
 	private boolean pinned;
-	private LocalDateTime createdAt;
+	private Instant createdAt;
 	private boolean updated;
 	private List<String> imageUrls;
 	private Integer likeCount;

--- a/src/main/java/hobbiedo/board/dto/CommentResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/CommentResponseDto.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,5 +19,5 @@ public class CommentResponseDto {
 	private String writerProfileImageUrl; // 작성자 프로필 이미지 url
 	private String content; // 댓글 내용
 	private Boolean isInCrew; // 소모임 회원 여부
-	private LocalDateTime createdAt; // 작성일
+	private Instant createdAt; // 작성일
 }

--- a/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.vo;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import hobbiedo.board.dto.BoardDetailsResponseDto;
@@ -20,7 +20,7 @@ public class BoardDetailsResponseVo {
 	private String writerName;
 	private String writerProfileImageUrl;
 	private boolean pinned;
-	private LocalDateTime createdAt;
+	private Instant createdAt;
 	private boolean updated;
 	private List<String> imageUrls;
 	private Integer likeCount;
@@ -28,7 +28,7 @@ public class BoardDetailsResponseVo {
 
 	public BoardDetailsResponseVo(Long boardId, Long crewId, String content,
 		String writerUuid,
-		boolean pinned, LocalDateTime createdAt, boolean updated, List<String> imageUrls,
+		boolean pinned, Instant createdAt, boolean updated, List<String> imageUrls,
 		Integer likeCount,
 		Integer commentCount, String writerName, String writerProfileImageUrl) {
 		this.boardId = boardId;

--- a/src/main/java/hobbiedo/board/vo/CommentResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/CommentResponseVo.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.vo;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 import hobbiedo.board.dto.CommentResponseDto;
@@ -19,11 +19,11 @@ public class CommentResponseVo {
 	private String writerProfileImageUrl;
 	private String content; // 댓글 내용
 	private Boolean isInCrew; // 소모임 회원 여부
-	private LocalDateTime createdAt; // 작성일
+	private Instant createdAt; // 작성일
 
 	public CommentResponseVo(Long commentId, String writerUuid, String writerName,
 		String writerProfileImageUrl,
-		String content, Boolean isInCrew, LocalDateTime createdAt) {
+		String content, Boolean isInCrew, Instant createdAt) {
 		this.commentId = commentId;
 		this.writerUuid = writerUuid;
 		this.writerName = writerName;

--- a/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/LatestBoardDetailsResponseVo.java
@@ -1,6 +1,6 @@
 package hobbiedo.board.vo;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,14 +20,14 @@ public class LatestBoardDetailsResponseVo {
 	private String writerUuid;
 	private String writerName;
 	private String writerProfileImageUrl;
-	private LocalDateTime createdAt;
+	private Instant createdAt;
 	private List<String> thumbnailUrl;
 	private Integer likeCount;
 	private Integer commentCount;
 
 	public LatestBoardDetailsResponseVo(Long boardId, Long crewId, String content,
 		String writerUuid,
-		LocalDateTime createdAt, List<String> thumbnailUrl, Integer likeCount,
+		Instant createdAt, List<String> thumbnailUrl, Integer likeCount,
 		Integer commentCount, String writerName, String writerProfileImageUrl) {
 		this.boardId = boardId;
 		this.crewId = crewId;


### PR DESCRIPTION
## 📣 읽기 전용 Mongo DB 내 날짜 저장 필드 형식 수정
### 📅 날짜 -  2024.06.27

### 🌵Branch
feature/change-mongodb-date-field  → develop

### 📢 Description
**읽기 전용 서버에서 게시글의 시간 또는 댓글의 시간을 조회할 때 데이터 타입이 LocalDateTime 인데 이 때문에 프론트에서 UTC 시간에서 한국 시간으로 변환하는 과정이 되질 않아 각 테이블의 createAt 필드의 타입을 LocalDateTime 에서 Instant 타입으로 수정**

### 💬Issue Number
[#26 ] - ♻️[REFACTOR] 읽기 전용 Mongo DB 내 날짜 저장 필드 형식 수정 #26

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 배포 이후 프론트에서 붙여보고 추후 수정사항이 있으면 수정할 예정이다