### PR TITLE
[REFACTOR] 읽기 전용 Mongo DB 내 날짜 저장 형식 수정 및 게시글 조회 시 방장 여부 조회

### DIFF
--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -47,8 +47,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 		// 기존 LocalDateTime 객체
 		LocalDateTime localDateTime = eventDto.getCreatedAt();
 
-		// LocalDateTime 을 ZonedDateTime 으로 변환
-		ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.of("Asia/Seoul"));
+		// LocalDateTime 을 ZonedDateTime 으로 변환하여 UTC로 변환
+		ZonedDateTime zonedDateTime = localDateTime.atZone(ZoneId.systemDefault())
+			.withZoneSameInstant(ZoneId.of("UTC"));
 
 		// ZonedDateTime 을 Instant 로 변환
 		Instant instant = zonedDateTime.toInstant();

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -217,6 +217,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
 			replicaBoard.getWriterUuid());
 
+		boolean hostStatus = replicaCrewService.isHost(replicaBoard.getCrewId(),
+			replicaBoard.getWriterUuid());
+
 		return BoardDetailsResponseDto.builder()
 			.boardId(replicaBoard.getBoardId())
 			.crewId(replicaBoard.getCrewId())
@@ -230,6 +233,7 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 			.likeCount(replicaBoard.getLikeCount())
 			.writerName(writerName)
 			.writerProfileImageUrl(writerProfileImageUrl)
+			.hostStatus(hostStatus)
 			.build();
 	}
 

--- a/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
+++ b/src/main/java/hobbiedo/board/application/ReplicaBoardServiceImpl.java
@@ -21,6 +21,7 @@ import hobbiedo.board.kafka.dto.BoardLikeCountUpdateDto;
 import hobbiedo.board.kafka.dto.BoardPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUnPinEventDto;
 import hobbiedo.board.kafka.dto.BoardUpdateEventDto;
+import hobbiedo.crew.application.ReplicaCrewService;
 import hobbiedo.global.api.exception.handler.ReadOnlyExceptionHandler;
 import hobbiedo.member.application.ReplicaMemberService;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 
 	// 회원 서비스 추가
 	private final ReplicaMemberService replicaMemberService;
+
+	// 소모임 서비스 추가
+	private final ReplicaCrewService replicaCrewService;
 
 	/**
 	 * 게시글 CQRS 패턴을 통해 복제
@@ -179,6 +183,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
 			replicaBoard.getWriterUuid());
 
+		boolean hostStatus = replicaCrewService.isHost(replicaBoard.getCrewId(),
+			replicaBoard.getWriterUuid());
+
 		return BoardDetailsResponseDto.builder()
 			.boardId(replicaBoard.getBoardId())
 			.crewId(replicaBoard.getCrewId())
@@ -192,6 +199,7 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 			.likeCount(replicaBoard.getLikeCount())
 			.writerName(writerName)
 			.writerProfileImageUrl(writerProfileImageUrl)
+			.hostStatus(hostStatus)
 			.build();
 	}
 
@@ -244,6 +252,9 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 		String writerProfileImageUrl = replicaMemberService.getMemberProfileImageUrl(
 			replicaBoard.get().getWriterUuid());
 
+		boolean hostStatus = replicaCrewService.isHost(replicaBoard.get().getCrewId(),
+			replicaBoard.get().getWriterUuid());
+
 		return BoardDetailsResponseDto.builder()
 			.boardId(replicaBoard.get().getBoardId())
 			.crewId(replicaBoard.get().getCrewId())
@@ -257,6 +268,7 @@ public class ReplicaBoardServiceImpl implements ReplicaBoardService {
 			.likeCount(replicaBoard.get().getLikeCount())
 			.writerName(writerName)
 			.writerProfileImageUrl(writerProfileImageUrl)
+			.hostStatus(hostStatus)
 			.build();
 	}
 

--- a/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
+++ b/src/main/java/hobbiedo/board/dto/BoardDetailsResponseDto.java
@@ -26,4 +26,5 @@ public class BoardDetailsResponseDto {
 	private Integer commentCount;
 	private String writerName;
 	private String writerProfileImageUrl;
+	private boolean hostStatus;
 }

--- a/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
+++ b/src/main/java/hobbiedo/board/vo/BoardDetailsResponseVo.java
@@ -25,12 +25,12 @@ public class BoardDetailsResponseVo {
 	private List<String> imageUrls;
 	private Integer likeCount;
 	private Integer commentCount;
+	private boolean hostStatus;
 
 	public BoardDetailsResponseVo(Long boardId, Long crewId, String content,
-		String writerUuid,
-		boolean pinned, Instant createdAt, boolean updated, List<String> imageUrls,
-		Integer likeCount,
-		Integer commentCount, String writerName, String writerProfileImageUrl) {
+		String writerUuid, boolean pinned, Instant createdAt, boolean updated,
+		List<String> imageUrls, Integer likeCount, Integer commentCount,
+		String writerName, String writerProfileImageUrl, boolean hostStatus) {
 		this.boardId = boardId;
 		this.crewId = crewId;
 		this.content = content;
@@ -43,6 +43,7 @@ public class BoardDetailsResponseVo {
 		this.commentCount = commentCount;
 		this.writerName = writerName;
 		this.writerProfileImageUrl = writerProfileImageUrl;
+		this.hostStatus = hostStatus;
 	}
 
 	public static BoardDetailsResponseVo boardDtoToDetailsVo(
@@ -65,7 +66,8 @@ public class BoardDetailsResponseVo {
 			boardResponseDto.getLikeCount(),
 			boardResponseDto.getCommentCount(),
 			boardResponseDto.getWriterName(),
-			boardResponseDto.getWriterProfileImageUrl()
+			boardResponseDto.getWriterProfileImageUrl(),
+			boardResponseDto.isHostStatus()
 		);
 	}
 }

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewService.java
@@ -13,4 +13,6 @@ public interface ReplicaCrewService {
 	void addCrewMember(CrewEntryExitDTO crewEntryExitDTO);
 
 	void deleteCrewMember(CrewEntryExitDTO crewEntryExitDTO);
+
+	boolean isHost(Long crewId, String writerUuid);
 }

--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
@@ -77,4 +77,21 @@ public class ReplicaCrewServiceImp implements ReplicaCrewService {
 		return replicaCrewRepository.findByCrewId(crewId)
 			.orElseThrow(() -> new ReadOnlyExceptionHandler(ErrorStatus.NOT_FOUND_CREW));
 	}
+
+	/**
+	 * 소모임장 여부 확인
+	 * @param crewId
+	 * @param writerUuid
+	 * @return
+	 */
+	@Override
+	public boolean isHost(Long crewId, String writerUuid) {
+
+		Crew crew = getCrew(crewId);
+
+		// 소모임원 중 소모임장인지 확인
+		return crew.getCrewMembers().stream()
+			.anyMatch(
+				crewMember -> crewMember.getUuid().equals(writerUuid) && crewMember.isHostStatus());
+	}
 }


### PR DESCRIPTION
## 📣 읽기 전용 Mongo DB 내 날짜 저장 형식 수정 및 게시글 조회 시 방장 여부 조회
### 📅 날짜 -  2024.06.28

### 🌵Branch
modify-date-field-format-mongodb  → develop

### 📢 Description
**읽기 전용 Mongo DB 내 날짜 저장 형식을 기존처럼 UTC 시간대로 수정하고 및 게시글 조회 시 방장 여부 조회**

### 💬Issue Number
[#26 ] - ♻️[REFACTOR] 읽기 전용 Mongo DB 내 날짜 저장 필드 형식 수정 #26

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
1. 방장 여부는 로컬에서 테스트가 제한이 되어 배포에서 해볼 예정