### PR TITLE
[refactor] CrewMember 도메인에서 name, profileUrl 제거 후, Profile 도메인에서 불러 오기

### DIFF
--- a/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
+++ b/src/main/java/hobbiedo/crew/application/ReplicaCrewServiceImp.java
@@ -27,7 +27,11 @@ public class ReplicaCrewServiceImp implements ReplicaCrewService {
 	public List<CrewMemberDTO> getCrewMembers(long crewId, String uuid) {
 		Crew crew = getCrew(crewId);
 		return crew.getCrewMembers().stream()
-			.map(crewMember -> CrewMemberDTO.toDto(crewMember, determineRole(crewMember, uuid)))
+			.map(crewMember -> {
+				MemberProfile memberProfile = getMemberProfile(crewMember.getUuid());
+				return CrewMemberDTO.toDto(crewMember, memberProfile,
+					determineRole(crewMember, uuid));
+			})
 			.sorted(Comparator.comparing(CrewMemberDTO::getRole).reversed())
 			.toList();
 	}
@@ -42,18 +46,13 @@ public class ReplicaCrewServiceImp implements ReplicaCrewService {
 
 	@Override
 	public void createCrew(CrewEntryExitDTO crewEntryExitDTO) {
-		MemberProfile memberProfile = getMemberProfile(crewEntryExitDTO.getUuid());
-		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(memberProfile,
-			true); // crew 생성 때 소모임장 추가
+		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(true); // crew 생성 때 소모임장 추가
 		replicaCrewRepository.save(crewEntryExitDTO.toCrewEntity(List.of(crewMember)));
 	}
 
 	@Override
 	public void addCrewMember(CrewEntryExitDTO crewEntryExitDTO) {
-
-		MemberProfile memberProfile = getMemberProfile(crewEntryExitDTO.getUuid());
-		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(memberProfile,
-			false); // crew 가입 때 소모임원 추가
+		CrewMember crewMember = crewEntryExitDTO.toCrewMemberEntity(false); // crew 가입 때 소모임원 추가
 		Crew crew = getCrew(crewEntryExitDTO.getCrewId());
 		crew.getCrewMembers().add(crewMember);
 		replicaCrewRepository.save(crew);

--- a/src/main/java/hobbiedo/crew/domain/CrewMember.java
+++ b/src/main/java/hobbiedo/crew/domain/CrewMember.java
@@ -13,15 +13,11 @@ import lombok.NoArgsConstructor;
 public class CrewMember {
 
 	private String uuid;
-	private String name;
-	private String profileUrl;
 	private boolean hostStatus;
 
 	@Builder
-	public CrewMember(String uuid, String name, String profileUrl, boolean hostStatus) {
+	public CrewMember(String uuid, boolean hostStatus) {
 		this.uuid = uuid;
-		this.name = name;
-		this.profileUrl = profileUrl;
 		this.hostStatus = hostStatus;
 	}
 }

--- a/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
+++ b/src/main/java/hobbiedo/crew/dto/response/CrewMemberDTO.java
@@ -1,6 +1,7 @@
 package hobbiedo.crew.dto.response;
 
 import hobbiedo.crew.domain.CrewMember;
+import hobbiedo.member.domain.MemberProfile;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,11 +13,11 @@ public class CrewMemberDTO {
 	private String profileUrl;
 	private int role; // 0:일반 소모임원, 1:소모임장, 2:나, 3:나 & 소모임장
 
-	public static CrewMemberDTO toDto(CrewMember crewMember, int role) {
+	public static CrewMemberDTO toDto(CrewMember crewMember, MemberProfile memberProfile, int role) {
 		return CrewMemberDTO.builder()
 			.uuid(crewMember.getUuid())
-			.name(crewMember.getName())
-			.profileUrl(crewMember.getProfileUrl())
+			.name(memberProfile.getName())
+			.profileUrl(memberProfile.getProfileUrl())
 			.role(role)
 			.build();
 	}

--- a/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
+++ b/src/main/java/hobbiedo/crew/kafka/dto/CrewEntryExitDTO.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import hobbiedo.crew.domain.Crew;
 import hobbiedo.crew.domain.CrewMember;
-import hobbiedo.member.domain.MemberProfile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,11 +15,9 @@ public class CrewEntryExitDTO {
 	private long crewId;
 	private String uuid;
 
-	public CrewMember toCrewMemberEntity(MemberProfile memberProfile, boolean hostStatus) {
+	public CrewMember toCrewMemberEntity(boolean hostStatus) {
 		return CrewMember.builder()
 			.uuid(uuid)
-			.name(memberProfile.getName())
-			.profileUrl(memberProfile.getProfileUrl())
 			.hostStatus(hostStatus)
 			.build();
 	}


### PR DESCRIPTION
## 📣 [refactor] CrewMember 도메인에서 name, profileUrl 제거 후, Profile 도메인에서 불러 오기
### 📅 2024.07.02

### 🌵Branch
feature/refactor-get-chat-profile → develop

### 📢 Description
- CrewMember 도메인에서 name, profileUrl 제거
- 채팅 소모임원 프로필 조회 시, Profile 도메인에서 불러 오기

### 💬Issue Number
[#31 ] - [REFACTOR] CrewMember 테이블에서 name, profileUrl 필드 제거

### 🛠️Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
